### PR TITLE
Moved all metadata into the request context for logging.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,4 +35,9 @@ class ApplicationController < ActionController::Base
   def request_id
     request.env['action_dispatch.request_id']
   end
+
+  def logstasher_add_visit_id(visit_id)
+    LogStasher.request_context[:visit_id] = visit_id
+    LogStasher.custom_fields << :visit_id
+  end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,14 +1,6 @@
 class ConfirmationsController < ApplicationController
   helper_method :booked_visit
   permit_only_from_prisons
-  before_action :preserve_tracer_metadata
-
-  def preserve_tracer_metadata
-    if visit = session[:booked_visit]
-      @tracer_visit_id = visit.visit_id
-      @tracer_prison = visit.prisoner.prison_name
-    end
-  end
 
   def new
     reset_session if params[:state]
@@ -18,6 +10,7 @@ class ConfirmationsController < ApplicationController
       reset_session
       render '_already_booked'
     end
+    logstasher_add_visit_id(booked_visit.visit_id)
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     render '_bad_state', status: 400
   end
@@ -37,10 +30,10 @@ class ConfirmationsController < ApplicationController
     end
     PrisonMailer.booking_receipt_email(booked_visit, @confirmation).deliver
     redirect_to confirmation_path
-    reset_session
   end
 
   def show
+    reset_session
   end
 
   def booked_visit

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,7 +1,8 @@
 if LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    fields[:request_id] = request.env['action_dispatch.request_id']
-    fields[:visit_id] = @tracer_visit_id if @tracer_visit_id
-    fields[:prison] = @tracer_prison if @tracer_prison
+  LogStasher.add_custom_fields_to_request_context do |fields|
+    if visit = session[:visit] || session[:booked_visit]
+      fields[:visit_id] = visit.visit_id
+      fields[:prison] = visit.prisoner.prison_name
+    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,13 @@ describe ApplicationController do
       Raven.extra_context.should == {request_id: 'request_id', visit_id: 'visit-id', prison: 'Rochester'}
       response['X-Request-Id'].should == 'request_id'
     end
+
+    it "sets additional metadata for logstasher" do
+      visit_id = "LOL"
+      LogStasher.request_context.should_receive(:[]=).with(:visit_id, visit_id)
+      LogStasher.custom_fields.should_receive(:<<).with(:visit_id)
+      controller.logstasher_add_visit_id(visit_id)
+    end
   end
 
   context "when IP & key restriction is enabled" do

--- a/spec/controllers/visit_controller_spec.rb
+++ b/spec/controllers/visit_controller_spec.rb
@@ -43,10 +43,11 @@ describe VisitController do
     describe "step 1 - enter prisoner's details" do
       before :each do
         Timecop.freeze(Time.local(2013, 12, 1, 12, 00))
-        controller.should_receive(:preserve_tracer_metadata).at_least(1).and_call_original
       end
 
       it "renders the form for entering prisoner details, and assigns the session" do
+        SecureRandom.should_receive(:hex).and_return(visit_id = 'LOL' * 10)
+        controller.should_receive(:logstasher_add_visit_id).with(visit_id)
         expect {
           get :prisoner_details
           response.should be_success
@@ -121,7 +122,6 @@ describe VisitController do
     describe "step 2" do
       before :each do
         Timecop.freeze(Time.local(2013, 12, 1, 12, 00))
-        controller.should_receive(:preserve_tracer_metadata).at_least(1).and_call_original
       end
 
       context "given valid visitor information" do
@@ -310,7 +310,6 @@ describe VisitController do
     describe "step 4 - select a timeslot" do
       before :each do
         Timecop.freeze(Time.local(2013, 12, 1, 12, 0))
-        controller.should_receive(:preserve_tracer_metadata).at_least(1).and_call_original
         get :prisoner_details
       end
 
@@ -394,7 +393,6 @@ describe VisitController do
 
       before :each do
         Timecop.freeze(Time.local(2013, 12, 1, 12, 0))
-        controller.should_receive(:preserve_tracer_metadata).at_least(1).and_call_original
         ActionMailer::Base.deliveries.clear
         subject.stub(:metrics_logger).and_return(mock_metrics_logger)
 


### PR DESCRIPTION
Removed some no-longer-needed code.
Moved reset_session to the show action to ensure that we'll be able to see the visit_id throughout the confirmation process.
Added a helper method around a hack for setting visit_id.
