### PR TITLE
Changed 'processing' to 'not booked yet'

### DIFF
--- a/app/views/visit/status.html.haml
+++ b/app/views/visit/status.html.haml
@@ -6,8 +6,8 @@
   %h1 Your visit request has been rejected
   %p You should have received an email to say that your visit cannot take place as planned.
 - when :pending
-  %h1 Your visit is currently being processed
-  %p Your visit request is currently being processed. You’ll get a confirmation email within 3 working days.
+  %h1 Your visit is not booked yet
+  %p Your visit request has not yet been processed by visit booking staff. You should get a visit confirmation email within 3 working days of making your request.
 %p If you don’t receive an email within 3 days, please check your spam or junk folder. You need to do this on a computer or tablet (rather than a smart phone).
 %p
   To stop visit confirmation emails going to your spam or junk folder please add


### PR DESCRIPTION
This is to address user confusion about what 'processing' means - need to make it clear that visit is not booked yet
