### PR TITLE
Changed header to 'contact us' for clarity

### DIFF
--- a/app/views/feedbacks/new.html.haml
+++ b/app/views/feedbacks/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :header, "Send feedback"
+- content_for :header, "Contact us"
 
 .Grid
   .Grid-2-3


### PR DESCRIPTION
Need to make it clear to users that they can expect us to reply - rather than just send in their feedback. 
@jasiek - would be great if you could merge this please. 
