### PR TITLE
Updating form to direct users to prisons instead of zen desk

### DIFF
--- a/app/views/feedbacks/_form.html.haml
+++ b/app/views/feedbacks/_form.html.haml
@@ -1,14 +1,15 @@
 %p If you need to ask a question about: 
 
-- whether your visit has been booked 
+%ul
+  %li whether your visit has been booked 
+  %li cancelling or changing visit details eg names of visitors, dates or times
+  %li what you can bring when you visit, eg clothes or money 
+  %li prisoner's contact lists or visiting allowance
 
-- cancelling or changing visit details eg names of visitors, dates or times
-
-- what you can bring when you visit, eg clothes or money 
-
-- prisoner's contact lists or visiting allowance
-
-%p You must [contact the prison](http://www.justice.gov.uk/contacts/prison-finder) for help. 
+%p
+  You must 
+  %a(href="http://www.justice.gov.uk/contacts/prison-finder") contact the prison
+  for help. 
 
 %p You can use this form to tell us about a problem you’re having with the visit request website, or to ask us a question about how to use it. 
 


### PR DESCRIPTION
Making it clearer to users when they should contact prisons, and when they should use zen desk (pivotal #79773854)
