### PR TITLE
Updated copy for for date to be inserted

### DIFF
--- a/app/helpers/visit_helper.rb
+++ b/app/helpers/visit_helper.rb
@@ -77,4 +77,9 @@ module VisitHelper
       return visiting_slots[day.strftime('%a').downcase.to_sym]
     end
   end
+
+  def when_to_expect_reply(today=Date.today)
+    schedule = Schedule.new(prison_data)
+    format_day(schedule.except_lead_days(today, schedule.default_booking_range(today)).first)
+  end
 end

--- a/app/views/visit/choose_date_and_time.html.haml
+++ b/app/views/visit/choose_date_and_time.html.haml
@@ -88,7 +88,7 @@
 
             %select.SlotPicker-input(name='visit[slots][][slot]')
               %option(value='') none
-              - Schedule.new(prison_data).dates(Date.today, 28).each do |date|
+              - Schedule.new(prison_data).dates(Date.today).each do |date|
                 - slots_for_day(date).each do |slot|
                   - value = [date.strftime('%Y-%m-%d'), slot.join('-')].join('-')
                   %option{ value: value, selected: ('selected' if value == current_slots[index]) }= date.strftime('%A, %e %B - ') + Time.strptime(slot[0].to_s, '%H%M').strftime('%l:%M%P')

--- a/app/views/visit/request_sent.html.haml
+++ b/app/views/visit/request_sent.html.haml
@@ -4,9 +4,12 @@
   .Grid-2-3
     %p 
       %strong Your visit is not booked yet:
-      you'll get a confirmation email to 
+      you'll get an email to 
       = mail_to visit.visitors.first.email
-      within 3 working days. If you don't get a confirmation email, please
+      by
+      = when_to_expect_reply
+      to confirm the date and time of your visit. 
+      If you don't get a confirmation email, please
       = conditional_text prison_phone, 'call ', ' or'
       email us at #{prison_email_link}.
 

--- a/app/views/visitor_mailer/booking_receipt_email.text.erb
+++ b/app/views/visitor_mailer/booking_receipt_email.text.erb
@@ -5,7 +5,7 @@ YOUR VISIT IS NOT BOOKED YET
 You can check the status of your request here:
 <%= visit_status_url(@visit.visit_id) %>
 
-We have received your visit request. We'll email you within 3 working days to confirm a date and time. Please don't contact us sooner than 3 working days, as we won't be able to comment on booking requests that are being processed.
+We've received your visit request. We'll email you by <%= when_to_expect_reply %> to confirm the date and time of your visit. Please don't contact us any sooner than that, as we won't be able to comment on booking requests that are being processed.
 
 If you don’t receive a confirmation email within 3 working days, please check your spam or junk folder for it. You need to do this on a computer or tablet (rather than a smart phone).
 

--- a/lib/schedule.rb
+++ b/lib/schedule.rb
@@ -1,16 +1,20 @@
 class Schedule
   WEEK_DAYS_MAP = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 }.invert
+  DEFAULT_BOOKING_WINDOW = 28 # days
+  DEFAULT_LEAD_DAYS = 3 # days
+
+  attr_reader :lead_days
 
   def initialize(prison_data_for_prison)
     @unbookable_dates = prison_data_for_prison[:unbookable].to_set
     @visiting_slots = prison_data_for_prison[:slots]
     @anomalous_dates = (prison_data_for_prison[:slot_anomalies] || {}).keys
     @works_weekends = prison_data_for_prison[:works_weekends]
-    @lead_days = prison_data_for_prison[:lead_days] || 3
+    @lead_days = prison_data_for_prison[:lead_days] || DEFAULT_LEAD_DAYS
   end
 
-  def dates(starting_when, how_many_days)
-    except_lead_days(starting_when, @lead_days, except_days_without_slots(except_unbookable(starting_when..(starting_when + how_many_days))))
+  def dates(starting_when)
+    except_lead_days(starting_when, except_days_without_slots(except_unbookable(default_booking_range(starting_when))))
   end
 
   def except_unbookable(enumerable)
@@ -29,7 +33,7 @@ class Schedule
     end
   end
 
-  def except_lead_days(start_date, lead_days, enumerable)
+  def except_lead_days(start_date, enumerable)
     if lead_days == 0
       offsets = {
         0 => 0,
@@ -60,6 +64,10 @@ class Schedule
         end
       end
     end
+  end
+
+  def default_booking_range(starting_when)
+    starting_when..(starting_when + DEFAULT_BOOKING_WINDOW)
   end
 end
 

--- a/spec/helpers/visit_helper_spec.rb
+++ b/spec/helpers/visit_helper_spec.rb
@@ -74,6 +74,10 @@ describe VisitHelper do
     it "provides all the slots for a particular day" do
       helper.anomalies_for_day(Date.parse("2014-08-14")).should == [["0700", "0900"]]
     end
+
+    it "provides a formatted date for when a response may be sent out" do
+      helper.when_to_expect_reply(Date.parse("2014-10-03")).should == "Monday  6 October"
+    end
   end
 
   it "should provide the prison name" do

--- a/spec/lib/schedule_spec.rb
+++ b/spec/lib/schedule_spec.rb
@@ -15,21 +15,21 @@ describe Schedule do
     end
     
     it "returns days within 28 days, excluding the lead days" do
-      subject.dates(start_date, 28).each do |date|
+      subject.dates(start_date).each do |date|
         date.should >= start_date + 3
         date.should <= start_date + 28
       end
     end
 
     it "rejects unbookable dates" do
-      subject.dates(start_date, 28).each do |date|
+      subject.dates(start_date).each do |date|
         date.should_not == Date.parse('2014-12-25')
         date.should_not == Date.parse('2014-12-26')
       end
     end
 
     it "offers visits every day of the week" do
-      subject.dates(start_date, 10).collect do |date|
+      subject.dates(start_date).collect do |date|
         date.wday
       end.sort == 7.times.to_a
     end
@@ -45,25 +45,25 @@ describe Schedule do
       # 31
 
       start_date = Date.new(2014, 8, 18) # Monday
-      subject.dates(start_date, 14).first.should == start_date + 4 # Friday
+      subject.dates(start_date).first.should == start_date + 4 # Friday
 
       start_date = Date.new(2014, 8, 19) # Tuesday
-      subject.dates(start_date, 14).first.should == start_date + 4 # Saturday
+      subject.dates(start_date).first.should == start_date + 4 # Saturday
 
       start_date = Date.new(2014, 8, 20) # Wednesday
-      subject.dates(start_date, 14).first.should == start_date + 6 # Tuesday
+      subject.dates(start_date).first.should == start_date + 6 # Tuesday
 
       start_date = Date.new(2014, 8, 21) # Thursday
-      subject.dates(start_date, 14).first.should == start_date + 6 # Wednesday
+      subject.dates(start_date).first.should == start_date + 6 # Wednesday
 
       start_date = Date.new(2014, 8, 22) # Friday
-      subject.dates(start_date, 14).first.should == start_date + 6 # Thursday
+      subject.dates(start_date).first.should == start_date + 6 # Thursday
 
       start_date = Date.new(2014, 8, 23) # Saturday
-      subject.dates(start_date, 14).first.should == start_date + 5 # Thursday
+      subject.dates(start_date).first.should == start_date + 5 # Thursday
 
       start_date = Date.new(2014, 8, 24) # Sunday
-      subject.dates(start_date, 14).first.should == start_date + 4 # Thursday
+      subject.dates(start_date).first.should == start_date + 4 # Thursday
     end
   end
 
@@ -73,7 +73,7 @@ describe Schedule do
     end
 
     it "rejects days without slots" do
-      subject.dates(start_date, 28).each do |date|
+      subject.dates(start_date).each do |date|
         date.wday.should_not == 5
       end
     end
@@ -86,7 +86,7 @@ describe Schedule do
 
     it "does indeed work on weekends" do
       (Date.new(2014, 8, 18)..Date.new(2014, 8, 24)).each do |start_date|
-        subject.dates(start_date, 14).first.should == start_date + 4
+        subject.dates(start_date).first.should == start_date + 4
       end
     end
   end
@@ -101,7 +101,7 @@ describe Schedule do
         date.wday == 3
       end
       prison[:slot_anomalies] = {anomalous_date => ['0945-1300']}
-      subject.dates(Date.new(2014, 1, 1), 60).to_a.should include anomalous_date
+      subject.dates(Date.new(2014, 1, 1)).to_a.should include anomalous_date
     end
   end
 
@@ -121,7 +121,7 @@ describe Schedule do
     it "allows earlier bookings" do
       prison[:lead_days] = 0
 
-      subject.dates(start_date, 28).first.should == start_date + 2
+      subject.dates(start_date).first.should == start_date + 2
     end
 
     context "which works on weekends" do
@@ -132,7 +132,7 @@ describe Schedule do
       it "allows earlier bookings" do
         prison[:lead_days] = 0
 
-        subject.dates(start_date, 28).first.should == start_date + 1
+        subject.dates(start_date).first.should == start_date + 1
       end
     end
   end
@@ -155,33 +155,33 @@ describe Schedule do
 
       # Monday
       start_date = Date.new(2014, 12, 1)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 1
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 1
 
       # Tuesday
       start_date = Date.new(2014, 12, 2)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 1
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 1
 
       # Wednesday
       start_date = Date.new(2014, 12, 3)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 1
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 1
 
       # Thursday
       start_date = Date.new(2014, 12, 4)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 1
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 1
 
       # Friday
       start_date = Date.new(2014, 12, 5)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 3
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 3
 
       # Saturday
       start_date = Date.new(2014, 12, 6)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 2
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 2
 
       # Sunday
       start_date = Date.new(2014, 12, 7)
-      subject.except_lead_days(start_date, 0, date_range).first.should == start_date + 1
+      subject.except_lead_days(start_date, date_range).first.should == start_date + 1
 
-      subject.dates(start_date = Date.new(2014, 12, 4), 28).first.should == start_date + 1
+      subject.dates(start_date = Date.new(2014, 12, 4)).first.should == start_date + 1
     end
   end
 end

--- a/spec/mailers/visitor_mailer_spec.rb
+++ b/spec/mailers/visitor_mailer_spec.rb
@@ -128,6 +128,7 @@ describe VisitorMailer do
         email[:to].should == visitor_address
         email.body.raw_source.should_not include("Jimmy Harris")
         email.body.raw_source.should include(visit_status_url(id: sample_visit.visit_id))
+        email.body.raw_source.should match(/by Wednesday  8 October to/)
       end
     end
 


### PR DESCRIPTION
Instead of saying '3 working days' before users can expect a reply, we are calculating the actual date that they'll hear back by. Hopefuly this will cut down on requests from visitors.

[Finishes #79432124]
