### PR TITLE
Update subject lines for visitor emails

### DIFF
--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 class VisitorMailer < ActionMailer::Base
 
   include MailerHelper::NoReply
@@ -17,7 +18,7 @@ class VisitorMailer < ActionMailer::Base
     @slot = visit.slots[confirmation.slot.to_i]
     @message_from_prison = confirmation.message
 
-    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Your visit for #{Date.parse(@slot.date).strftime('%e %B %Y').gsub(/^ /,'')} has been confirmed")
+    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Visit confirmed: your visit for #{Date.parse(@slot.date).strftime('%e %B %Y').gsub(/^ /,'')} has been confirmed")
   end
 
   def booking_rejection_email(visit, confirmation)
@@ -25,13 +26,13 @@ class VisitorMailer < ActionMailer::Base
     @message_from_prison = confirmation.message
     @confirmation = confirmation
     
-    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Your visit for #{first_date.strftime('%e %B %Y').gsub(/^ /,'')} could not be booked")
+    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Visit cannot take place: your visit for #{first_date.strftime('%e %B %Y').gsub(/^ /,'')} could not be booked")
   end
 
   def booking_receipt_email(visit)
     @visit = visit
 
-    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Your visit request for #{first_date.strftime('%e %B %Y').gsub(/^ /,'')} will be processed soon")
+    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Not booked yet: we've received your visit request for #{first_date.strftime('%e %B %Y').gsub(/^ /,'')}")
   end
 
   def sender

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -98,7 +98,7 @@ describe ConfirmationsController do
         after :each do
           post :create, confirmation: { outcome: 'slot_0' }, state: encrypted_visit
           response.should redirect_to(confirmation_path)
-          ActionMailer::Base.deliveries.map(&:subject).should == ["Your visit for 7 July 2013 has been confirmed", "COPY of booking confirmation for Jimmy Harris"]
+          ActionMailer::Base.deliveries.map(&:subject).should == ["Visit confirmed: your visit for 7 July 2013 has been confirmed", "COPY of booking confirmation for Jimmy Harris"]
         end
       end
 
@@ -112,7 +112,7 @@ describe ConfirmationsController do
         after :each do
           post :create, confirmation: { outcome: Confirmation::NOT_ON_CONTACT_LIST }, state: encrypted_visit
           response.should redirect_to(confirmation_path)
-          ActionMailer::Base.deliveries.map(&:subject).should == ["Your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"]
+          ActionMailer::Base.deliveries.map(&:subject).should == ["Visit cannot take place: your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"]
         end
       end
 
@@ -126,7 +126,7 @@ describe ConfirmationsController do
         after :each do
           post :create, confirmation: { outcome: Confirmation::NO_VOS_LEFT }, state: encrypted_visit
           response.should redirect_to(confirmation_path)
-          ActionMailer::Base.deliveries.map(&:subject).should == ["Your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"]
+          ActionMailer::Base.deliveries.map(&:subject).should == ["Visit cannot take place: your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"]
         end
       end
 
@@ -140,7 +140,7 @@ describe ConfirmationsController do
         after :each do
           post :create, confirmation: { outcome: 'no_slot_available' }, state: encrypted_visit
           response.should redirect_to(confirmation_path)
-          ActionMailer::Base.deliveries.map(&:subject).should == ["Your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"]
+          ActionMailer::Base.deliveries.map(&:subject).should == ["Visit cannot take place: your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"]
         end
       end
 

--- a/spec/controllers/visit_controller_spec.rb
+++ b/spec/controllers/visit_controller_spec.rb
@@ -475,7 +475,7 @@ describe VisitController do
         response.should redirect_to(request_sent_path)
 
         ActionMailer::Base.deliveries.map(&:subject).should == ['Visit request for Jimmy Harris on Friday  6 December',
-                                                                'Your visit request for 6 December 2013 will be processed soon']
+                                                                "Not booked yet: we've received your visit request for 6 December 2013"]
       end
 
       it "doesn't send out e-mails if in testing mode" do

--- a/spec/mailers/visitor_mailer_spec.rb
+++ b/spec/mailers/visitor_mailer_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require "spec_helper"
 
 describe VisitorMailer do
@@ -65,7 +66,7 @@ describe VisitorMailer do
     context "booking is successful" do
       it "sends out an e-mail" do
         email = subject.booking_confirmation_email(sample_visit, confirmation)
-        email.subject.should == "Your visit for 7 July 2013 has been confirmed"
+        email.subject.should == "Visit confirmed: your visit for 7 July 2013 has been confirmed"
 
         email[:from].should == noreply_address
         email[:reply_to].should == prison_address
@@ -90,7 +91,7 @@ describe VisitorMailer do
     context "booking is unsuccessful because of a slot not being available" do
       it "sends out an e-mail with a date in the subject" do
         email = subject.booking_rejection_email(sample_visit, confirmation_no_slot_available)
-        email.subject.should == "Your visit for 7 July 2013 could not be booked"
+        email.subject.should == "Visit cannot take place: your visit for 7 July 2013 could not be booked"
 
         email[:from].should == noreply_address
         email[:reply_to].should == prison_address
@@ -106,7 +107,7 @@ describe VisitorMailer do
     context "booking is unsuccessful because of a visitor not being on a contact list" do
       it "sends out an e-mail with a date in the subject" do
         email = subject.booking_rejection_email(sample_visit, confirmation_not_on_contact_list)
-        email.subject.should == "Your visit for 7 July 2013 could not be booked"
+        email.subject.should == "Visit cannot take place: your visit for 7 July 2013 could not be booked"
 
         email[:from].should == noreply_address
         email[:reply_to].should == prison_address
@@ -122,13 +123,13 @@ describe VisitorMailer do
     context "booking receipt sent" do
       it "sends out an e-mail with a date in the subject" do
         email = subject.booking_receipt_email(sample_visit)
-        email.subject.should == "Your visit request for 7 July 2013 will be processed soon"
+        email.subject.should == "Not booked yet: we've received your visit request for 7 July 2013"
         email[:from].should == noreply_address
         email[:reply_to].should == prison_address
         email[:to].should == visitor_address
         email.body.raw_source.should_not include("Jimmy Harris")
         email.body.raw_source.should include(visit_status_url(id: sample_visit.visit_id))
-        email.body.raw_source.should match(/by Wednesday  8 October to/)
+        email.body.raw_source.should match(/by Friday 10 October to/)
       end
     end
 


### PR DESCRIPTION
Making the content of the emails clearer to users with updated subject lines. Links to pivotal story https://www.pivotaltracker.com/story/show/79610206
