### PR TITLE
Closed visits 84122476

### DIFF
--- a/app/controllers/deferred/confirmations_controller.rb
+++ b/app/controllers/deferred/confirmations_controller.rb
@@ -48,7 +48,7 @@ class Deferred::ConfirmationsController < ApplicationController
   end
 
   def confirmation_params
-    params.require(:confirmation).permit(:outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo, :renew_pvo, :visitor_not_listed, :visitor_banned, :canned_response, banned_visitors: [], unlisted_visitors: [])
+    params.require(:confirmation).permit(:outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo, :renew_pvo, :closed_visit, :visitor_not_listed, :visitor_banned, :canned_response, banned_visitors: [], unlisted_visitors: [])
   end
 
   def encryptor

--- a/app/models/confirmation.rb
+++ b/app/models/confirmation.rb
@@ -1,6 +1,6 @@
 class Confirmation
   include ActiveModel::Model
-  attr_accessor :outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo, :renew_pvo, :banned_visitors, :unlisted_visitors, :visitor_not_listed, :visitor_banned, :canned_response
+  attr_accessor :outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo, :renew_pvo, :banned_visitors, :unlisted_visitors, :visitor_not_listed, :visitor_banned, :canned_response, :closed_visit
 
   NO_VOS_LEFT = 'no_vos_left'
   NO_SLOT_AVAILABLE = 'no_slot_available'

--- a/app/views/deferred/confirmations/_canned_responses.html.haml
+++ b/app/views/deferred/confirmations/_canned_responses.html.haml
@@ -41,11 +41,10 @@
         = text_field_tag 'confirmation[vo_number]', nil, :maxlength => 8
       
       .group
-        #closed_visit.field{ :class => ('validation-error' if f.object.errors.include?(:closed_visit)) }
+        #closed_visit.field
           %label.block-label(for='confirmation_closed_visit')
             = check_box_tag 'confirmation[closed_visit]', 1, f.object.closed_visit.present?, { :'data-conditional-el' => 'details_closed_visit', :class => 'js-Conditional' }
             This is a closed visit
-            %span.validation-message= f.object.errors[:closed_visit].first if f.object.errors.include?(:closed_visit)
 
         #details_closed_visit
           %h3 What we’ll tell the visitor

--- a/app/views/deferred/confirmations/_canned_responses.html.haml
+++ b/app/views/deferred/confirmations/_canned_responses.html.haml
@@ -39,6 +39,18 @@
           %p.form-hint eg Last 8 digits of VO number or "none" for remand
           %span.validation-message= f.object.errors[:vo_number].first if f.object.errors.include?(:vo_number)
         = text_field_tag 'confirmation[vo_number]', nil, :maxlength => 8
+      
+      .group
+        #closed_visit.field{ :class => ('validation-error' if f.object.errors.include?(:closed_visit)) }
+          %label.block-label(for='confirmation_closed_visit')
+            = check_box_tag 'confirmation[closed_visit]', 1, f.object.closed_visit.present?, { :'data-conditional-el' => 'details_closed_visit', :class => 'js-Conditional' }
+            This is a closed visit
+            %span.validation-message= f.object.errors[:closed_visit].first if f.object.errors.include?(:closed_visit)
+
+        #details_closed_visit
+          %h3 What we’ll tell the visitor
+          %p
+            %em.email This is a closed visit.
 
     %label.block-label(for='confirmation_outcome_no_slot_available' )
       = radio_button_tag 'confirmation[outcome]', Confirmation::NO_SLOT_AVAILABLE, false, { :'data-conditional-el' => 'details_no_slot_available', :class => 'js-Conditional' }

--- a/app/views/deferred/confirmations/_canned_responses.html.haml
+++ b/app/views/deferred/confirmations/_canned_responses.html.haml
@@ -49,7 +49,9 @@
         #details_closed_visit
           %h3 What we’ll tell the visitor
           %p
-            %em.email This is a closed visit.
+            %em.email
+              %strong This is a closed visit:
+              the prisoner will be behind a glass screen in a separate area rather than in the visiting hall. 
 
     %label.block-label(for='confirmation_outcome_no_slot_available' )
       = radio_button_tag 'confirmation[outcome]', Confirmation::NO_SLOT_AVAILABLE, false, { :'data-conditional-el' => 'details_no_slot_available', :class => 'js-Conditional' }

--- a/app/views/mailers_common/_booking_confirmation.html.haml
+++ b/app/views/mailers_common/_booking_confirmation.html.haml
@@ -49,6 +49,11 @@
     %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } Banned visitors should have received a letter to say that they’re banned from visiting the prison at the moment. Get in touch with the prison for more information. 
 
 
+- if @confirmation.closed_visit
+
+  %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } This is a closed visit.
+
+
 %h1{ style: 'margin:1em 0;font: bold 24px Helvetica, Arial, sans-serif' } Cancel or change this visit
 
 %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } If you no longer want to visit on this date, #{link_to('you can cancel this visit', visit_status_url(@visit.visit_id, state: @token))}.

--- a/app/views/mailers_common/_booking_confirmation.html.haml
+++ b/app/views/mailers_common/_booking_confirmation.html.haml
@@ -51,7 +51,9 @@
 
 - if @confirmation.closed_visit
 
-  %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } This is a closed visit.
+  %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' }
+    %strong This is a closed visit:
+    the prisoner will be behind a glass screen in a separate area rather than in the visiting hall.
 
 
 %h1{ style: 'margin:1em 0;font: bold 24px Helvetica, Arial, sans-serif' } Cancel or change this visit

--- a/app/views/mailers_common/_booking_confirmation.text.erb
+++ b/app/views/mailers_common/_booking_confirmation.text.erb
@@ -43,6 +43,10 @@ Visitors not on contact lists need to ask prisoners to update their lists with c
 Banned visitors should have received a letter to say that they’re banned from visiting the prison at the moment. Get in touch with the prison for more information. 
 <% end %>
 <% end %>
+<% if @confirmation.closed_visit %>
+
+This is a closed visit.
+<% end %>
 
 <%= @confirmation.message %>
 

--- a/app/views/mailers_common/_booking_confirmation.text.erb
+++ b/app/views/mailers_common/_booking_confirmation.text.erb
@@ -45,7 +45,7 @@ Banned visitors should have received a letter to say that they’re banned from 
 <% end %>
 <% if @confirmation.closed_visit %>
 
-This is a closed visit.
+This is a closed visit: the prisoner will be behind a glass screen in a separate area rather than in the visiting hall.
 <% end %>
 
 <%= @confirmation.message %>

--- a/spec/mailers/visitor_mailer_spec.rb
+++ b/spec/mailers/visitor_mailer_spec.rb
@@ -59,6 +59,10 @@ describe VisitorMailer do
     Confirmation.new(canned_response: true, vo_number: '5551234', outcome: 'slot_0', visitor_banned: true, banned_visitors: ['Joan;Harris'])
   end
 
+  let :confirmation_closed_visit do
+    Confirmation.new(canned_response: true, vo_number: '5551234', outcome: 'slot_0', closed_visit: true)
+  end
+
   let :confirmation_no_slot_available do
     Confirmation.new(message: 'A message', outcome: Confirmation::NO_SLOT_AVAILABLE)
   end
@@ -203,6 +207,19 @@ describe VisitorMailer do
 
         email.should match_in_html(sample_visit.visit_id)
         email.should match_in_text(sample_visit.visit_id)
+      end
+
+      it "sends out an e-mail notifying visitors that it is a closed visit" do
+        email = subject.booking_confirmation_email(sample_visit, confirmation_closed_visit, token)
+        email.subject.should == "Visit confirmed: your visit for 7 July 2013 has been confirmed"
+
+        email[:from].should == noreply_address
+        email[:reply_to].should == prison_address
+        email[:to].should == visitor_address
+
+        email.should_not match_in_html("Jimmy Harris")
+        email.should match_in_html('5551234')
+        email.should match_in_html('This is a closed visit')
       end
 
       it "sends out an e-mail with the List-Unsubscribe header set" do

--- a/test/mailers/previews/mailer_preview_common.rb
+++ b/test/mailers/previews/mailer_preview_common.rb
@@ -60,6 +60,10 @@ module MailerPreviewCommon
     Confirmation.new(outcome: 'slot_2', vo_number: '5551234', canned_response: true, visitor_not_listed: true, unlisted_visitors: ['Emma;Jones'], visitor_banned: true, banned_visitors: ['Mark;Jones'])
   end
 
+  def accepted_confirmation_closed_visit
+    Confirmation.new(outcome: 'slot_2', vo_number: '5551234', canned_response: true, closed_visit: true)
+  end
+
   def rejected_confirmation(outcome)
     Confirmation.new(outcome: outcome)
   end

--- a/test/mailers/previews/mailer_preview_common.rb
+++ b/test/mailers/previews/mailer_preview_common.rb
@@ -25,6 +25,17 @@ module MailerPreviewCommon
     MESSAGE_ENCRYPTOR
   end
 
+  def remove_unused_slots(visit, slot_index)
+    visit.dup.tap do |v|
+      selected_slot = visit.slots[slot_index]
+      v.slots = [selected_slot]
+    end
+  end
+
+  def token
+    encryptor.encrypt_and_sign(remove_unused_slots(sample_visit, accepted_confirmation.slot))
+  end
+
   def accepted_confirmation
     Confirmation.new(outcome: 'slot_2', message: 'A message')
   end

--- a/test/mailers/previews/visitor_mailer_preview.rb
+++ b/test/mailers/previews/visitor_mailer_preview.rb
@@ -2,11 +2,11 @@ class VisitorMailerPreview < ActionMailer::Preview
   include MailerPreviewCommon
 
   def booking_confirmation
-    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation)
+    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation, token)
   end
 
   def booking_confirmation_canned_response
-    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation_canned_response)
+    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation_canned_response, token)
   end
 
   def booking_confirmation_canned_response_remand
@@ -22,7 +22,7 @@ class VisitorMailerPreview < ActionMailer::Preview
   end
 
   def booking_confirmation_banned_and_unlisted_visitors
-    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation_visitor_banned_and_unlisted)
+    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation_visitor_banned_and_unlisted, token)
   end
 
   def booking_rejection_rejected_no_slots

--- a/test/mailers/previews/visitor_mailer_preview.rb
+++ b/test/mailers/previews/visitor_mailer_preview.rb
@@ -25,6 +25,10 @@ class VisitorMailerPreview < ActionMailer::Preview
     VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation_visitor_banned_and_unlisted, token)
   end
 
+  def booking_confirmation_closed_visit
+    VisitorMailer.booking_confirmation_email(sample_visit, accepted_confirmation_closed_visit, token)
+  end
+
   def booking_rejection_rejected_no_slots
     VisitorMailer.booking_rejection_email(sample_visit, rejected_confirmation('no_slot_available'))
   end


### PR DESCRIPTION
Add a checkbox to approved visit requests to notify visitors when the visit will be a 'closed visit'.

@jasiek please look at the [first commit](https://github.com/ministryofjustice/prison-visits/commit/17067293fa5c0ce96e73f9ae8726bd4fb56734be) first as I'm not convinced I've implemented the best way to replicate the token.