### PR TITLE
Fix: feature specs fail on date picker

### DIFF
--- a/spec/features/datepicker_spec.rb
+++ b/spec/features/datepicker_spec.rb
@@ -56,14 +56,11 @@ feature "visitor selects a date" do
           
           # For some reason, check() can't find the checkbox.
           if flow == :deferred
-            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1350-1520').click()"))
-            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1350-1450').click()"))
-            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1450-1550').click()"))
+            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1330-1500').click()"))
+            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1445-1545').click()"))
           else
-            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-0900-1145').click()"))
             evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1345-1545').click()"))
             evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1345-1645').click()"))
-            evaluate_script(_when.strftime("$('#slot-%Y-%m-%d-1715-1900').click()"))
           end
 
           click_button 'Continue'

--- a/spec/features/visitor_information_page_spec.rb
+++ b/spec/features/visitor_information_page_spec.rb
@@ -15,6 +15,11 @@ feature "visitor enters visitor information" do
       end
 
       context "and leaves fields blank" do
+        before :each do
+          EmailValidator.any_instance.stub(:validate_dns_records)
+          EmailValidator.any_instance.stub(:validate_spam_reporter)
+        end
+
         it "validation messages are present" do
           click_button 'Continue'
 
@@ -27,6 +32,11 @@ feature "visitor enters visitor information" do
       end
 
       context "and they fill out all fields" do
+        before :each do
+          EmailValidator.any_instance.stub(:validate)
+          EmailValidator.any_instance.stub(:validate)
+        end
+
         context "for one visitor" do
           it "displays the calendar" do
             enter_visitor_information(flow)


### PR DESCRIPTION
- regroup before blocks to allow email validation to pass and fail when required
- only allow instant bookings to find one slot per day
- deferred bookings slot times needed updating

Fixes 86118980