### PR TITLE
Fix additional visitors blocking DOB after 2014

### DIFF
--- a/app/views/shared/visitors_details/_visitor_fields.html.haml
+++ b/app/views/shared/visitors_details/_visitor_fields.html.haml
@@ -35,8 +35,8 @@
             %p.form-hint You must be over 18 to book a visit.
           %p.form-hint.datefield-hint eg 28 04 1996
         - dates = ['day', 'month', 'year']
-        - min = [1, 1, 1900]
-        - max = [31, 12, 2014]
+        - min = [1, 1, Date.today.year - 115]
+        - max = [31, 12, Date.today.year]
         - dates.each_with_index do |o, i|
           .datefield{ :class => "form-group form-group-#{o}" }
             %label{ :for => "visitor_date_of_birth_#{dates.count - i}i_#{index}" } #{o.mb_chars.titleize}


### PR DESCRIPTION
2014 was hard-coded into the DOB year for additional visitors year using the `max` attribute. This commit replaces that with a rolling year. And also sets the `min` attribute to a rolling 115 years back.