### PR TITLE
Better session timeout handling

### DIFF
--- a/app/controllers/prisoner_details_controller.rb
+++ b/app/controllers/prisoner_details_controller.rb
@@ -1,6 +1,8 @@
+require 'session_guard'
+
 class PrisonerDetailsController < ApplicationController
   include CookieGuard
-  include SessionGuard
+  include SessionGuardOnUpdateOnly
 
   def edit
     session[:visit] ||= new_session

--- a/lib/session_guard.rb
+++ b/lib/session_guard.rb
@@ -1,11 +1,6 @@
 module SessionGuard
   extend ActiveSupport::Concern
 
-  included do
-    before_filter :check_if_session_timed_out, only: :update
-    before_filter :check_if_session_exists, only: :update
-  end
-
   def check_if_session_timed_out
     unless visit
       redirect_to(edit_prisoner_details_path, notice: 'Your session timed out because no information was entered for more than 20 minutes.')
@@ -13,11 +8,19 @@ module SessionGuard
     end
     verify_authenticity_token
   end
+end
 
-  def check_if_session_exists
-    unless visit
-      redirect_to(edit_prisoner_details_path)
-      return
-    end
+module SessionGuardOnUpdateOnly
+  extend ActiveSupport::Concern
+  include SessionGuard
+
+  included do
+    before_filter :check_if_session_timed_out, only: :update
+  end
+end
+
+module SessionGuard
+  included do
+    before_filter :check_if_session_timed_out, only: [:update, :edit]
   end
 end


### PR DESCRIPTION
If there's no session, redirect with a timeout message on both `edit` and `update` actions.

[#88771750]