### PR TITLE
Each e-mail contains schema.org metadata about the booking event.

### DIFF
--- a/app/helpers/visit_helper.rb
+++ b/app/helpers/visit_helper.rb
@@ -37,16 +37,16 @@ module VisitHelper
     mail_to prison_data['email']
   end
 
-  def prison_postcode
-    prison_data['address'][-1]
+  def prison_postcode(source=visit)
+    prison_data(source)['address'][-1]
   end
 
   def prison_slot_anomalies
     prison_data['slot_anomalies']
   end
 
-  def prison_address(glue='<br>')
-    prison_data['address'].join(glue).html_safe
+  def prison_address(source=visit, glue='<br>')
+    prison_data(source)['address'].join(glue).html_safe
   end
 
   def adult_age
@@ -149,5 +149,33 @@ module VisitHelper
     visitors.inject([]) do |arr, visitor|
       arr << visitor.full_name(';')
     end
+  end
+
+  def event_schema_json(visit, slot)
+    {
+      "@context" => "http://schema.org",
+      "@type" => "EventReservation",
+      "reservationStatus" => "http://schema.org/Confirmed",
+      "underName" => {
+        "@type" => "Person",
+        "name" => visit.visitors.first.full_name
+      },
+      "reservationFor" => {
+        "@type" => "Event",
+        "name" => "Prison Visit",
+        "startDate" => slot.timestamps.first,
+        "endDate" => slot.timestamps.last,
+        "location" => {
+          "@type" => "Place",
+          "name" => "HMP " + prison_name(visit),
+          "address" => {
+            "@type" => "PostalAddress",
+            "streetAddress" => prison_address(visit, " "),
+            "postalCode" => prison_postcode(visit),
+            "addressCountry" => "GB"
+          }
+        }
+      }
+    }.to_json.html_safe
   end
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -18,4 +18,10 @@ class Slot
   def weekday
     Date.parse(date).strftime('%A')
   end
+
+  def timestamps
+    start_time, end_time = times.split('-').map do |t|
+      Time.parse([date, t.gsub(/(\d{2})(\d{2})/, '\1:\2:00')].join('T'))
+    end
+  end
 end

--- a/app/views/mailers_common/_booking_confirmation.html.haml
+++ b/app/views/mailers_common/_booking_confirmation.html.haml
@@ -114,3 +114,6 @@
 
 %p
   %small Visit ID: #{@visit.visit_id}
+
+%script{type: 'application/ld+json'}
+  = event_schema_json(@visit, @slot)

--- a/spec/mailers/visitor_mailer_spec.rb
+++ b/spec/mailers/visitor_mailer_spec.rb
@@ -136,6 +136,7 @@ describe VisitorMailer do
 
         email.should match_in_html(sample_visit.visit_id)
         email.should match_in_text(sample_visit.visit_id)
+        email.should match_in_html('http://schema.org/Confirmed')
       end
 
       it "sends out an e-mail with a reference number (canned responses)" do

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Slot do
+  subject do
+    Slot.new(date: '2014-05-22', times: '1200-1600')
+  end
+
+  it "generates timestamps for the view" do
+    subject.timestamps.should == [
+     Time.parse("2014-05-22T12:00:00"),
+     Time.parse("2014-05-22T16:00:00")
+    ]
+  end
+end


### PR DESCRIPTION
A button in Gmail that provides "add to calendar" functionality from email list view using schema.org.