### PR TITLE
Add staff alert for Easter bank holiday

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:ministryofjustice/prison_staff_info.git
-  revision: d60a47e1864fe692f43e044fd1239840fed97f28
+  revision: 44a267cbb57098d636374d6ddf5a0168adf674ab
   branch: master
   specs:
     prison_staff_info (0.0.2)

--- a/app/views/deferred/confirmations/show.html.haml
+++ b/app/views/deferred/confirmations/show.html.haml
@@ -5,9 +5,11 @@
       %h1 Thank you
       %p A confirmation email has been sent to the visitor.
 
-    - if Date.today < Date.parse('2015-01-30')
+    - if Date.today < Date.parse('2015-03-25')
       #latest-change.notice
-        %h1 Staff update: letting visitors know about closed visits
-        %p You can now let visitors know if they'll be attending a 'closed visit' when you process a visit booking request.
+        %h1 Staff update: visits on Easter Bank Holiday
+
+        %p Please notify us now if your social visits slots will change due to Easter Bank Holidays. Please email changes to prison-visits-feedback@digital.justice.gov.uk.
+
         %p
-          %a(href="/staff/changes") Read more about recent updates
+          %a(href="/staff/changes") Read about recent updates


### PR DESCRIPTION
Some prisons are closed for visits on Easter bank holiday. This is now within 28 days.

This PR puts an alert on front of booking staff once they finish processing visits and asks them to get in touch if they want us to block-out any dates over Easter.