### PR TITLE
Lindholme - May bank holiday time changes

### DIFF
--- a/config/prison_data_production.yml
+++ b/config/prison_data_production.yml
@@ -2450,6 +2450,10 @@ Lindholme:
     - 1345-1600
     2015-04-06:
     - 1345-1600
+    2015-05-04:
+    - 1345-1600
+    2015-05-25:
+    - 1345-1600
 Littlehey:
   nomis_id: LTI
   canned_responses: true

--- a/config/prison_data_staging.yml
+++ b/config/prison_data_staging.yml
@@ -2475,6 +2475,10 @@ Lindholme:
     - 1345-1600
     2015-04-06:
     - 1345-1600
+    2015-05-04:
+    - 1345-1600
+    2015-05-25:
+    - 1345-1600
 Littlehey:
   nomis_id: LTI
   canned_responses: true


### PR DESCRIPTION
May holiday time changes requested by Lindholme.

015-05-04:
    - 1345-1600
2015-05-25:
    - 1345-1600