### PR TITLE
Set adult age to 10 for HMP Onley

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ The visit request processing form has been updated and can be enabled per prison
 canned_responses: true
 ```
 
+### Adult age
+
+Visit requests are limited to a maximum of 3 adults. Visiting areas have 3 seats for visitors and one for the prisoner. Children are expect to sit on the laps of adults.
+
+**default: 18**
+
+```yaml
+adult_age: 16 # allow only 3 visitors over the age of 16
+```
+
 ## Set-up
 
 Clone the project into a directory on to your environment using [instructions on GitHub](https://help.github.com/categories/54/articles).

--- a/config/prison_data_production.yml
+++ b/config/prison_data_production.yml
@@ -771,6 +771,7 @@ Onley:
   phone: 01788 523 402
   email: socialvisits.onley@hmps.gsi.gov.uk
   instant_booking: false
+  adult_age: 10
   address:
   - Willoughby
   - CV23 8AP


### PR DESCRIPTION
HMP Onley have a policy of a seat for people 10 years old and over. This change limits bookings to visits of 3 ten year olds by setting the `adult_age` configuration to 10.

This change affects only one prison.

**Note:** This is the first prison to have a custom adult age since the [feature was implemented](https://github.com/ministryofjustice/prison-visits/pull/157), but I think mistakenly didn't put any of the [custom adult ages](https://github.com/ministryofjustice/prison-visits/pull/157/files#diff-0e9afe10f18cbb928426fdf3690f7b74) into production.