### PR TITLE
Haverigg - changing definition of adult to 10 years old

### DIFF
--- a/config/prison_data_production.yml
+++ b/config/prison_data_production.yml
@@ -1578,6 +1578,7 @@ Haverigg:
   canned_responses: true
   enabled: true
   phone: 01229713016
+  adult_age: 10
   email: socialvisits.haverigg@hmps.gsi.gov.uk
   instant_booking: false
   address:

--- a/config/prison_data_staging.yml
+++ b/config/prison_data_staging.yml
@@ -1596,6 +1596,7 @@ Haverigg:
   canned_responses: true
   enabled: true
   phone: 01229713016
+  adult_age: 10
   email: pvb.haverigg@maildrop.dsd.io
   instant_booking: false
   address:


### PR DESCRIPTION
Haverigg contacted us to request that we lower the definition of
‘adult’ from 18 to 10 years as they are struggling with seating. This
change will ensure that less visitors attend.