### PR TITLE
Portland - request to lower adult age to 11 years

### DIFF
--- a/config/prison_data_production.yml
+++ b/config/prison_data_production.yml
@@ -2525,6 +2525,7 @@ Portland:
   phone: 01305 715775
   email: socialvisits.portland@hmps.gsi.gov.uk
   instant_booking: false
+  adult_age: 11
   address:
   - 104 The Grove
   - DT5 1DL


### PR DESCRIPTION
Portland have requested that we reduce the adult age to 11 yrs due to
seating restrictions.