### PR TITLE
Brinsford/Hewell/Stoke Heath/Swinfen Hall/Werrington - Adults aged 10…

### DIFF
--- a/config/prison_data_production.yml
+++ b/config/prison_data_production.yml
@@ -177,6 +177,7 @@ Brinsford:
   phone: 0300 060 6500
   email: visitsbooking.westmidlands@noms.gsi.gov.uk
   instant_booking: false
+  adult_age: 10
   address:
   - New Road
   - Featherstone
@@ -255,6 +256,7 @@ Werrington:
   phone: 0300 060 6508
   email: visitsbooking.westmidlands@noms.gsi.gov.uk
   instant_booking: false
+  adult_age: 10
   address:
   - Werrington
   - Stoke-On-Trent
@@ -316,6 +318,7 @@ Stoke Heath:
   phone: 0300 060 6506
   email: visitsbooking.westmidlands@noms.gsi.gov.uk
   instant_booking: false
+  adult_age: 10
   address:
   - Market Drayton
   - Shropshire
@@ -347,6 +350,7 @@ Swinfen Hall:
   phone: 0300 060 6507
   email: visitsbooking.westmidlands@noms.gsi.gov.uk
   instant_booking: false
+  adult_age: 10
   address:
   - Swinfen Hall
   - FLichfield
@@ -376,6 +380,7 @@ Hewell:
   phone: 0300 060 6503
   email: visitsbooking.westmidlands@noms.gsi.gov.uk
   instant_booking: false
+  adult_age: 10
   address:
   - Hewell Lane
   - Redditch

--- a/config/prison_data_staging.yml
+++ b/config/prison_data_staging.yml
@@ -182,6 +182,7 @@ Brinsford:
   phone: 0300 060 6500
   email: pvb.brinsford@maildrop.dsd.io
   instant_booking: false
+  adult_age: 10
   address:
   - New Road
   - Featherstone
@@ -260,7 +261,7 @@ Werrington:
   phone: 0300 060 6508
   email: pvb.werrington@maildrop.dsd.io
   instant_booking: false
-  adult_age: 16
+  adult_age: 10
   address:
   - Werrington
   - Stoke-On-Trent
@@ -322,6 +323,7 @@ Stoke Heath:
   phone: 0300 060 6506
   email: pvb.stokeheath@maildrop.dsd.io
   instant_booking: false
+  adult_age: 10
   address:
   - Market Drayton
   - Shropshire
@@ -353,6 +355,7 @@ Swinfen Hall:
   phone: 0300 060 6507
   email: pvb.swinfenhall@maildrop.dsd.io
   instant_booking: false
+  adult_age: 10
   address:
   - Swinfen Hall
   - FLichfield
@@ -382,6 +385,7 @@ Hewell:
   phone: 0300 060 6503
   email: pvb.hewell@maildrop.dsd.io
   instant_booking: false
+  adult_age: 10
   address:
   - Hewell Lane
   - Redditch


### PR DESCRIPTION
… and over

APVU have asked us to change the adult ages for Brinsford, Hewell,
Stoke Heath, Swinfen Hall and Werrington to 10yrs and older due to seat
restrictions at the prison.