### PR TITLE
Ensure healthcheck 5XXs on poor health

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -2,12 +2,14 @@ class HeartbeatController < ApplicationController
   permit_only_with_key
 
   def healthcheck
-    render json: {
-      checks: {
-        sendgrid: sendgrid_alive?,
-        messagelabs: messagelabs_alive?,
-        database: ActiveRecord::Base.connection.active?
-      }
+    checks = {
+      sendgrid: sendgrid_alive?,
+      messagelabs: messagelabs_alive?,
+      database: ActiveRecord::Base.connection.active?,
+    }
+    status = :bad_gateway unless checks.values.all?
+    render status: status, json: {
+      checks: checks
     }
   end
 

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -2,10 +2,16 @@ class HeartbeatController < ApplicationController
   permit_only_with_key
 
   def healthcheck
+    database_active = begin
+      ActiveRecord::Base.connection.active?
+    rescue PG::ConnectionBad
+      false
+    end
+
     checks = {
       sendgrid: sendgrid_alive?,
       messagelabs: messagelabs_alive?,
-      database: ActiveRecord::Base.connection.active?,
+      database: database_active,
     }
     status = :bad_gateway unless checks.values.all?
     render status: status, json: {

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -30,6 +30,43 @@ describe HeartbeatController do
         parsed_body['checks']['sendgrid'].should be_true
         parsed_body['checks']['database'].should be_true
       end
+
+      it "errors if messagelabs is down" do
+        PrisonMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(false)
+        VisitorMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(true)
+        get :healthcheck
+
+        assert_response(:bad_gateway, response.status)
+        parsed_body = JSON.parse(response.body)
+        parsed_body['checks']['messagelabs'].should be_false
+      end
+
+      it "errors if sendgrid is down" do
+        PrisonMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(true)
+        VisitorMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(false)
+        get :healthcheck
+
+        assert_response(:bad_gateway, response.status)
+        parsed_body = JSON.parse(response.body)
+        parsed_body['checks']['sendgrid'].should be_false
+      end
+
+      it "errors if the database is down" do
+        PrisonMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(true)
+        VisitorMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(true)
+        ActiveRecord::Base.connection.should_receive(:active?).once.and_return(false)
+        get :healthcheck
+
+        assert_response(:bad_gateway, response.status)
+        parsed_body = JSON.parse(response.body)
+        parsed_body['checks']['database'].should be_false
+      end
     end
   end
 end

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -27,47 +27,62 @@ describe HeartbeatController do
         controller.stub(:reject_without_key!)
       end
 
-      it "talks to sendgrid and messagelabs" do
-        set_mock_mailer_response(PrisonMailer, true)
-        set_mock_mailer_response(VisitorMailer, true)
-        get :healthcheck
+      context "when everything is OK" do
+        before :each do
+          set_mock_mailer_response(PrisonMailer, true)
+          set_mock_mailer_response(VisitorMailer, true)
+        end
 
-        assert_response(:success, response.status)
-        parsed_body = JSON.parse(response.body)
-        parsed_body['checks']['messagelabs'].should be_true
-        parsed_body['checks']['sendgrid'].should be_true
-        parsed_body['checks']['database'].should be_true
+        it "returns a HTTP Success status" do
+          get :healthcheck
+          assert_response(:success, response.status)
+        end
+
+        it "reports all services as OK" do
+          get :healthcheck
+          parsed_body = JSON.parse(response.body)
+          parsed_body['checks'].values.all?.should be_true
+        end
+
+        [
+          'sendgrid',
+          'messagelabs',
+          'database',
+        ].each do |service|
+          it "contains a check for #{service}" do
+            get :healthcheck
+            parsed_body = JSON.parse(response.body)
+            parsed_body['checks'].has_key?(service).should be_true
+          end
+        end
       end
 
-      it "errors if messagelabs is down" do
-        set_mock_mailer_response(PrisonMailer, false)
-        set_mock_mailer_response(VisitorMailer, true)
-        get :healthcheck
+      context "when messagelabs is down" do
+        before :each do
+          set_mock_mailer_response(PrisonMailer, false)
+          set_mock_mailer_response(VisitorMailer, true)
+        end
 
-        assert_response(:bad_gateway, response.status)
-        parsed_body = JSON.parse(response.body)
-        parsed_body['checks']['messagelabs'].should be_false
+        it_behaves_like "a service is broken", "messagelabs"
       end
 
-      it "errors if sendgrid is down" do
-        set_mock_mailer_response(PrisonMailer, true)
-        set_mock_mailer_response(VisitorMailer, false)
-        get :healthcheck
+      context "when sendgrid is down" do
+        before :each do
+          set_mock_mailer_response(PrisonMailer, true)
+          set_mock_mailer_response(VisitorMailer, false)
+        end
 
-        assert_response(:bad_gateway, response.status)
-        parsed_body = JSON.parse(response.body)
-        parsed_body['checks']['sendgrid'].should be_false
+        it_behaves_like "a service is broken", "sendgrid"
       end
 
-      it "errors if the database is down" do
-        set_mock_mailer_response(PrisonMailer, true)
-        set_mock_mailer_response(VisitorMailer, true)
-        ActiveRecord::Base.connection.should_receive(:active?).once.and_return(false)
-        get :healthcheck
+      context "when the database is down" do
+        before :each do
+          set_mock_mailer_response(PrisonMailer, true)
+          set_mock_mailer_response(VisitorMailer, true)
+          ActiveRecord::Base.connection.should_receive(:active?).once.and_return(false)
+        end
 
-        assert_response(:bad_gateway, response.status)
-        parsed_body = JSON.parse(response.body)
-        parsed_body['checks']['database'].should be_false
+        it_behaves_like "a service is broken", "database"
       end
     end
   end

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -84,6 +84,16 @@ describe HeartbeatController do
 
         it_behaves_like "a service is broken", "database"
       end
+
+      context "when the database is off" do
+        before :each do
+          set_mock_mailer_response(PrisonMailer, true)
+          set_mock_mailer_response(VisitorMailer, true)
+          ActiveRecord::Base.connection.should_receive(:active?).once.and_raise(PG::ConnectionBad)
+        end
+
+        it_behaves_like "a service is broken", "database"
+      end
     end
   end
 end

--- a/spec/controllers/heartbeat_controller_spec.rb
+++ b/spec/controllers/heartbeat_controller_spec.rb
@@ -2,27 +2,33 @@ require 'spec_helper'
 
 describe HeartbeatController do
   render_views
-  
-  context "key restrictions" do
-    context "are enabled" do
+
+  context "with key restrictions" do
+    context "enabled" do
       it "raises an error" do
         Rails.configuration.metrics_auth_key = ""
         controller.should_receive(:reject!)
         get :healthcheck
       end
     end
-        
-    context "are disabled" do
+
+    context "disabled" do
       before :each do
         controller.stub(:reject_without_key!)
       end
 
       it "talks to sendgrid and messagelabs" do
         PrisonMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
-        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(true)
         VisitorMailer.should_receive(:smtp_settings).and_return(address: host = double, port: port = double)
-        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once
+        SendgridHelper.should_receive(:smtp_alive?).with(host, port).once.and_return(true)
         get :healthcheck
+
+        assert_response(:success, response.status)
+        parsed_body = JSON.parse(response.body)
+        parsed_body['checks']['messagelabs'].should be_true
+        parsed_body['checks']['sendgrid'].should be_true
+        parsed_body['checks']['database'].should be_true
       end
     end
   end

--- a/spec/support/heartbeat_support.rb
+++ b/spec/support/heartbeat_support.rb
@@ -1,0 +1,12 @@
+shared_examples "a service is broken" do |service|
+  it "returns a HTTP Bad Gateway status" do
+    get :healthcheck
+    assert_response(:bad_gateway, response.status)
+  end
+
+  it "reports #{service} as inaccessible" do
+    get :healthcheck
+    parsed_body = JSON.parse(response.body)
+    parsed_body['checks'][service].should be_false
+  end
+end


### PR DESCRIPTION
When services we depend on are down (Sendgrid, Messagelabs, and the database), the healthcheck endpoint should return a HTTP 5XX response so that Pingdom fires alerts when things go awry.