### PR TITLE
Raise useful exception when prison not found

### DIFF
--- a/app/controllers/deferred/slots_controller.rb
+++ b/app/controllers/deferred/slots_controller.rb
@@ -5,7 +5,10 @@ class Deferred::SlotsController < ApplicationController
 
   def edit
     @slots = visit.slots.empty? ? [Slot.new, Slot.new, Slot.new] : visit.slots
-    @schedule = Schedule.new(Rails.configuration.prison_data[visit.prisoner.prison_name], Rails.configuration.bank_holidays)
+    @schedule = Schedule.new(
+      Rails.configuration.prison_data.fetch(visit.prisoner.prison_name),
+      Rails.configuration.bank_holidays
+    )
   end
 
   def max_slots

--- a/app/helpers/visit_helper.rb
+++ b/app/helpers/visit_helper.rb
@@ -18,7 +18,7 @@ module VisitHelper
   end
 
   def prison_data(source=visit)
-    Rails.configuration.prison_data[source.prisoner.prison_name.to_s]
+    Rails.configuration.prison_data.fetch(source.prisoner.prison_name.to_s)
   end
 
   def prison_name(source=visit)


### PR DESCRIPTION
In issues #208 and #209, we see exceptions raised when there is no prison data for the prison name supplied. It's more helpful to raise an exception earlier that tells us that the key does not exist in the prison data hash.

Instead of:

    ActionView::Template::Error: undefined method `[]' for nil:NilClass

the exception raised by an unknown prison name is now:

    KeyError: key not found: "bar"

This should assist us in tracking down the root cause of these errors.