### PR TITLE
Clean code and improve coverage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,4 +63,12 @@ class ApplicationController < ActionController::Base
   def visit
     session[:visit]
   end
+
+  def encryptor
+    MESSAGE_ENCRYPTOR
+  end
+
+  def metrics_logger
+    METRICS_LOGGER
+  end
 end

--- a/app/controllers/deferred/confirmations_controller.rb
+++ b/app/controllers/deferred/confirmations_controller.rb
@@ -81,22 +81,6 @@ class Deferred::ConfirmationsController < ApplicationController
     visit
   end
 
-  def migrate_visitors(visit)
-    visit.dup.tap do |visit|
-      visit.visitors.map! do |visitor|
-        if visitor.class == Visitor
-          values = [:first_name, :last_name, :email, :index, :number_of_adults, :number_of_children, :date_of_birth, :phone].inject({}) do |h, selector|
-            h[selector] = visitor.send(selector)
-            h
-          end
-          Deferred::Visitor.new(values)
-        else
-          visitor
-        end
-      end
-    end
-  end
-
   def remove_unused_slots(visit, slot_index)
     visit.dup.tap do |v|
       selected_slot = visit.slots[slot_index]

--- a/app/controllers/deferred/confirmations_controller.rb
+++ b/app/controllers/deferred/confirmations_controller.rb
@@ -56,14 +56,6 @@ class Deferred::ConfirmationsController < ApplicationController
     params.require(:confirmation).permit(:outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo, :renew_pvo, :closed_visit, :visitor_not_listed, :visitor_banned, :canned_response, banned_visitors: [], unlisted_visitors: [])
   end
 
-  def encryptor
-    MESSAGE_ENCRYPTOR
-  end
-
-  def metrics_logger
-    METRICS_LOGGER
-  end
-
   def legacy_data_fixes(visit)
     if prison_name = {
         'Hollesley Bay' => 'Hollesley Bay Open',

--- a/app/controllers/deferred/visits_controller.rb
+++ b/app/controllers/deferred/visits_controller.rb
@@ -21,12 +21,4 @@ class Deferred::VisitsController < ApplicationController
     render
     reset_session
   end
-
-  def encryptor
-    MESSAGE_ENCRYPTOR
-  end
-
-  def metrics_logger
-    METRICS_LOGGER
-  end
 end

--- a/app/controllers/instant/visits_controller.rb
+++ b/app/controllers/instant/visits_controller.rb
@@ -19,12 +19,4 @@ class Instant::VisitsController < ApplicationController
     render
     reset_session
   end
-
-  def encryptor
-    MESSAGE_ENCRYPTOR
-  end
-
-  def metrics_logger
-    METRICS_LOGGER
-  end
 end

--- a/app/controllers/visit_controller.rb
+++ b/app/controllers/visit_controller.rb
@@ -31,12 +31,4 @@ class VisitController < ApplicationController
 
     redirect_to visit_status_path(id: params[:id], state: params[:state])
   end
-
-  def encryptor
-    MESSAGE_ENCRYPTOR
-  end
-
-  def metrics_logger
-    METRICS_LOGGER
-  end
 end

--- a/app/helpers/prisoner_details_helper.rb
+++ b/app/helpers/prisoner_details_helper.rb
@@ -1,9 +1,0 @@
-module PrisonerDetailsHelper
-  def instant_booking?
-    false
-  end
-
-  def process_as_email?
-    false
-  end
-end

--- a/app/helpers/visit_helper.rb
+++ b/app/helpers/visit_helper.rb
@@ -21,10 +21,6 @@ module VisitHelper
     Rails.configuration.prison_data.fetch(source.prisoner.prison_name.to_s)
   end
 
-  def prison_name(source=visit)
-    source.prisoner.prison_name
-  end
-
   def prison_phone
     prison_data['phone']
   end

--- a/app/models/confirmation.rb
+++ b/app/models/confirmation.rb
@@ -16,6 +16,16 @@ class Confirmation
   validate :unlisted
   validate :banned
 
+  def slot_selected?
+    [0, 1, 2].include?(slot)
+  end
+
+  def slot
+    outcome && outcome.starts_with?('slot') && outcome.gsub('slot_', '').to_i
+  end
+
+private
+
   def check_outcome
     outcomes = [
       NO_VOS_LEFT,
@@ -58,13 +68,5 @@ class Confirmation
     if visitor_not_listed && unlisted_visitors.nil?
       errors.add(:unlisted, 'one or more visitors must be selected')
     end
-  end
-
-  def slot_selected?
-    [0, 1, 2].include?(slot)
-  end
-
-  def slot
-    outcome && outcome.starts_with?('slot') && outcome.gsub('slot_', '').to_i
   end
 end

--- a/app/models/confirmation.rb
+++ b/app/models/confirmation.rb
@@ -1,6 +1,8 @@
 class Confirmation
   include ActiveModel::Model
-  attr_accessor :outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo, :renew_pvo, :banned_visitors, :unlisted_visitors, :visitor_not_listed, :visitor_banned, :canned_response, :closed_visit
+  attr_accessor :outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo,
+    :renew_pvo, :banned_visitors, :unlisted_visitors, :visitor_not_listed,
+    :visitor_banned, :canned_response, :closed_visit
 
   NO_VOS_LEFT = 'no_vos_left'
   NO_SLOT_AVAILABLE = 'no_slot_available'
@@ -10,11 +12,11 @@ class Confirmation
   NOT_ON_CONTACT_LIST = 'not_on_contact_list'
   SLOTS_RESPONSES = %w{slot_0 slot_1 slot_2}
 
-  validate :check_outcome
-  validate :reference
-  validate :renewals
-  validate :unlisted
-  validate :banned
+  validate :validate_outcome
+  validate :validate_reference
+  validate :validate_renewals
+  validate :validate_unlisted_visitors
+  validate :validate_banned_visitors
 
   def slot_selected?
     [0, 1, 2].include?(slot)
@@ -26,7 +28,7 @@ class Confirmation
 
 private
 
-  def check_outcome
+  def unknown_outcome?
     outcomes = [
       NO_VOS_LEFT,
       NO_SLOT_AVAILABLE,
@@ -35,37 +37,40 @@ private
       PRISONER_NOT_PRESENT,
       NOT_ON_CONTACT_LIST,
     ] + SLOTS_RESPONSES
+    !outcomes.include?(outcome)
+  end
 
-    if !outcomes.include?(outcome) && !visitor_not_listed && !visitor_banned
+  def validate_outcome
+    if unknown_outcome? && !visitor_not_listed && !visitor_banned
       errors.add(:outcome, 'an outcome must be chosen')
     end
   end
 
-  def reference
+  def validate_reference
     if SLOTS_RESPONSES.include?(outcome) && vo_number.blank? && canned_response
       errors.add(:vo_number, 'you must supply a reference number')
     end
   end
 
-  def renewals
+  def validate_renewals
     if outcome == NO_ALLOWANCE
-      if no_vo.present? && renew_vo.nil?
+      if no_vo.present? && renew_vo.blank?
         errors.add(:no_vo, 'a renewal date must be chosen')
       end
-      if no_pvo.present? && renew_pvo.nil?
+      if no_pvo.present? && renew_pvo.blank?
         errors.add(:no_pvo, 'a renewal date must be chosen')
       end
     end
   end
 
-  def banned
-    if visitor_banned && banned_visitors.nil?
+  def validate_banned_visitors
+    if visitor_banned && banned_visitors.blank?
       errors.add(:banned, 'one or more visitors must be selected')
     end
   end
 
-  def unlisted
-    if visitor_not_listed && unlisted_visitors.nil?
+  def validate_unlisted_visitors
+    if visitor_not_listed && unlisted_visitors.blank?
       errors.add(:unlisted, 'one or more visitors must be selected')
     end
   end

--- a/config/initializers/metrics_logger.rb
+++ b/config/initializers/metrics_logger.rb
@@ -1,4 +1,2 @@
 ELASTIC_CLIENT = Elasticsearch::Client.new(url: ENV['ELASTICSEARCH_URL'])
 METRICS_LOGGER = MetricsLogger.new
-
-

--- a/spec/models/confirmation_spec.rb
+++ b/spec/models/confirmation_spec.rb
@@ -1,0 +1,353 @@
+require 'spec_helper'
+
+describe Confirmation do
+
+  context 'errors' do
+    subject { described_class.new }
+
+    describe 'outcome' do
+      context 'when outcome is a listed outcome' do
+        it 'is valid when visitor is not listed and visitor is banned' do
+          subject.outcome = 'no_vos_left'
+          subject.visitor_not_listed = true
+          subject.visitor_banned = true
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+
+        it 'is valid when visitor is not listed and visitor is not banned' do
+          subject.outcome = 'no_vos_left'
+          subject.visitor_not_listed = true
+          subject.visitor_banned = false
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+
+        it 'is valid when visitor is listed and visitor is banned' do
+          subject.outcome = 'no_vos_left'
+          subject.visitor_not_listed = false
+          subject.visitor_banned = true
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+
+        it 'is valid when visitor is listed and visitor is not banned' do
+          subject.outcome = 'no_vos_left'
+          subject.visitor_not_listed = false
+          subject.visitor_banned = false
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+      end
+
+      context 'when outcome is bogus' do
+        it 'is valid when visitor is not listed and visitor is banned' do
+          subject.outcome = 'BOGUS'
+          subject.visitor_not_listed = true
+          subject.visitor_banned = true
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+
+        it 'is valid when visitor is not listed and visitor is not banned' do
+          subject.outcome = 'BOGUS'
+          subject.visitor_not_listed = true
+          subject.visitor_banned = false
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+
+        it 'is valid when visitor is listed and visitor is banned' do
+          subject.outcome = 'BOGUS'
+          subject.visitor_not_listed = false
+          subject.visitor_banned = true
+          subject.valid?
+          expect(subject.errors[:outcome]).to be_blank
+        end
+
+        it 'is invalid when visitor is listed and visitor is not banned' do
+          subject.outcome = 'BOGUS'
+          subject.visitor_not_listed = false
+          subject.visitor_banned = false
+          subject.valid?
+          expect(subject.errors[:outcome]).to include('an outcome must be chosen')
+        end
+      end
+    end
+
+    describe 'vo_number' do
+      context 'when outcome is not a slot' do
+        before do
+          subject.outcome = 'no_vos_left'
+        end
+
+        it 'is valid when vo_number is present and canned_response is true' do
+          subject.vo_number = '1234abcd12'
+          subject.canned_response = true
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+
+        it 'is valid when vo_number is present and canned_response is false' do
+          subject.vo_number = '1234abcd12'
+          subject.canned_response = false
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+
+        it 'is valid when vo_number is blank and canned_response is true' do
+          subject.vo_number = ''
+          subject.canned_response = true
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+
+        it 'is valid when vo_number is blank and canned_response is false' do
+          subject.vo_number = ''
+          subject.canned_response = false
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+      end
+
+      context 'when outcome is a slot' do
+        before do
+          subject.outcome = 'slot_0'
+        end
+
+        it 'is valid when vo_number is present and canned_response is true' do
+          subject.vo_number = '1234abcd12'
+          subject.canned_response = true
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+
+        it 'is valid when vo_number is present and canned_response is false' do
+          subject.vo_number = '1234abcd12'
+          subject.canned_response = false
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+
+        it 'is invalid when vo_number is blank and canned_response is true' do
+          subject.vo_number = ''
+          subject.canned_response = true
+          subject.valid?
+          expect(subject.errors[:vo_number]).
+            to include('you must supply a reference number')
+        end
+
+        it 'is valid when vo_number is blank and canned_response is false' do
+          subject.vo_number = ''
+          subject.canned_response = false
+          subject.valid?
+          expect(subject.errors[:vo_number]).to be_blank
+        end
+      end
+    end
+
+    describe 'no_vo' do
+      context 'when outcome is no_allowance' do
+        before do
+          subject.outcome = 'no_allowance'
+        end
+
+        it 'is valid when no_vo is present and renew_vo is present' do
+          subject.no_vo = 'yes'
+          subject.renew_vo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+
+        it 'is invalid when no_vo is present and renew_vo is nil' do
+          subject.no_vo = 'yes'
+          subject.renew_vo = nil
+          subject.valid?
+          expect(subject.errors[:no_vo]).
+            to include('a renewal date must be chosen')
+        end
+
+        it 'is valid when no_vo is blank and renew_vo is present' do
+          subject.no_vo = ''
+          subject.renew_vo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+
+        it 'is valid when no_vo is blank and renew_vo is nil' do
+          subject.no_vo = ''
+          subject.renew_vo = nil
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+      end
+
+      context 'when outcome is not no_allowance' do
+        before do
+          subject.outcome = 'prisoner_incorrect'
+        end
+
+        it 'is valid when no_vo is present and renew_vo is present' do
+          subject.no_vo = 'yes'
+          subject.renew_vo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+
+        it 'is valid when no_vo is present and renew_vo is nil' do
+          subject.no_vo = 'yes'
+          subject.renew_vo = nil
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+
+        it 'is valid when no_vo is blank and renew_vo is present' do
+          subject.no_vo = ''
+          subject.renew_vo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+
+        it 'is valid when no_vo is blank and renew_vo is nil' do
+          subject.no_vo = ''
+          subject.renew_vo = nil
+          subject.valid?
+          expect(subject.errors[:no_vo]).to be_blank
+        end
+      end
+    end
+
+    describe 'no_pvo' do
+      context 'when outcome is no_allowance' do
+        before do
+          subject.outcome = 'no_allowance'
+        end
+
+        it 'is valid when no_pvo is present and renew_pvo is present' do
+          subject.no_pvo = 'yes'
+          subject.renew_pvo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+
+        it 'is invalid when no_pvo is present and renew_pvo is nil' do
+          subject.no_pvo = 'yes'
+          subject.renew_pvo = nil
+          subject.valid?
+          expect(subject.errors[:no_pvo]).
+            to include('a renewal date must be chosen')
+        end
+
+        it 'is valid when no_pvo is blank and renew_pvo is present' do
+          subject.no_pvo = ''
+          subject.renew_pvo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+
+        it 'is valid when no_pvo is blank and renew_pvo is nil' do
+          subject.no_pvo = ''
+          subject.renew_pvo = nil
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+      end
+
+      context 'when outcome is not no_allowance' do
+        before do
+          subject.outcome = 'prisoner_incorrect'
+        end
+
+        it 'is valid when no_pvo is present and renew_pvo is present' do
+          subject.no_pvo = 'yes'
+          subject.renew_pvo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+
+        it 'is valid when no_pvo is present and renew_pvo is nil' do
+          subject.no_pvo = 'yes'
+          subject.renew_pvo = nil
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+
+        it 'is valid when no_pvo is blank and renew_pvo is present' do
+          subject.no_pvo = ''
+          subject.renew_pvo = '2020-01-01'
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+
+        it 'is valid when no_pvo is blank and renew_pvo is nil' do
+          subject.no_pvo = ''
+          subject.renew_pvo = nil
+          subject.valid?
+          expect(subject.errors[:no_pvo]).to be_blank
+        end
+      end
+    end
+
+    describe 'banned' do
+      it 'is valid when visitor_banned is true and banned_visitors is present' do
+        subject.visitor_banned = true
+        subject.banned_visitors = ['John;Smith']
+        subject.valid?
+        expect(subject.errors[:banned]).to be_blank
+      end
+
+      it 'is invalid when visitor_banned is true and banned_visitors is nil' do
+        subject.visitor_banned = true
+        subject.banned_visitors = nil
+        subject.valid?
+        expect(subject.errors[:banned]).
+          to include('one or more visitors must be selected')
+      end
+
+      it 'is valid when visitor_banned is false and banned_visitors is present' do
+        subject.visitor_banned = false
+        subject.banned_visitors = ['John;Smith']
+        subject.valid?
+        expect(subject.errors[:banned]).to be_blank
+      end
+
+      it 'is valid when visitor_banned is false and banned_visitors is nil' do
+        subject.visitor_banned = false
+        subject.banned_visitors = nil
+        subject.valid?
+        expect(subject.errors[:banned]).to be_blank
+      end
+    end
+
+    describe 'unlisted' do
+      it 'is valid when visitor_not_listed is true and unlisted_visitors is present' do
+        subject.visitor_not_listed = true
+        subject.unlisted_visitors = ['John;Smith']
+        subject.valid?
+        expect(subject.errors[:unlisted]).to be_blank
+      end
+
+      it 'is invalid when visitor_not_listed is true and unlisted_visitors is nil' do
+        subject.visitor_not_listed = true
+        subject.unlisted_visitors = nil
+        subject.valid?
+        expect(subject.errors[:unlisted]).
+          to include('one or more visitors must be selected')
+      end
+
+      it 'is valid when visitor_not_listed is false and unlisted_visitors is present' do
+        subject.visitor_not_listed = false
+        subject.unlisted_visitors = ['John;Smith']
+        subject.valid?
+        expect(subject.errors[:unlisted]).to be_blank
+      end
+
+      it 'is valid when visitor_not_listed is false and unlisted_visitors is nil' do
+        subject.visitor_not_listed = false
+        subject.unlisted_visitors = nil
+        subject.valid?
+        expect(subject.errors[:unlisted]).to be_blank
+      end
+    end
+  end
+end

--- a/spec/models/instant/visitor_spec.rb
+++ b/spec/models/instant/visitor_spec.rb
@@ -16,6 +16,10 @@ describe Instant::Visitor do
     end
   end
 
+  it 'generates an initial from the last name' do
+    visitor.last_initial.should == 'F'
+  end
+
   it_behaves_like 'a visitor'
 
   it "validates the first visitor as a lead visitor" do

--- a/spec/models/prisoner_spec.rb
+++ b/spec/models/prisoner_spec.rb
@@ -61,4 +61,8 @@ describe Prisoner do
     prisoner.date_of_birth = nil
     prisoner.age.should be_nil
   end
+
+  it 'generates an initial from the last name' do
+    prisoner.last_initial.should == 'H'
+  end
 end


### PR DESCRIPTION
* Removes some code that is never used (as established by Simplecov – see #212 – and inspection).
* Improves coverage from about 91 to 96%.
* Makes some small improvements to structure and readability where coverage was adequate to give confidence.

The most notable removal is of the legacy visit migrations. This was implemented for a structural change in December last year. Five months on, we can be confident that we won't need to process any more of these legacy requests, and this code is now superfluous.