### PR TITLE
Decouple prison-specific ID requirements from Rails internals

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,4 +62,17 @@ module ApplicationHelper
     end
     @nomis_id_to_prison[nomis_id]
   end
+
+  def markdown(source)
+    renderer = ::Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true)
+    options = {
+      autolink: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+      superscript: true
+    }
+    ::Redcarpet::Markdown.new(renderer, options).render(source).html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,14 +65,7 @@ module ApplicationHelper
 
   def markdown(source)
     renderer = ::Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true)
-    options = {
-      autolink: true,
-      no_intra_emphasis: true,
-      fenced_code_blocks: true,
-      lax_html_blocks: true,
-      strikethrough: true,
-      superscript: true
-    }
+    options = Rails.application.config.redcarpet_markdown_options
     ::Redcarpet::Markdown.new(renderer, options).render(source).html_safe
   end
 end

--- a/app/helpers/visit_helper.rb
+++ b/app/helpers/visit_helper.rb
@@ -87,28 +87,14 @@ module VisitHelper
     format_day(schedule.except_lead_days(today, schedule.booking_range(today)).first)
   end
 
-  def custom_id_requirements(prison_name, format)
-    nomis_id = Rails.configuration.prison_data[prison_name][:nomis_id]
-    label = "id_#{nomis_id}"
-    template = lookup_context.find_template(label, 'content', true)
-    case format
-    when :html
-      render File.join('content', label)
-    when :text
-      File.read(template.identifier)
-    end
-  rescue ActionView::MissingTemplate
-    nil
-  end
-
-  def standard_id_requirements(format)
-    template = lookup_context.find_template('standard_id_requirements', 'content', true)
-    case format
-    when :html
-      template.render(nil, nil)
-    when :text
-      File.read(template.identifier)
-    end
+  def prison_specific_id_requirements(prison_name)
+    nomis_id = Rails.configuration.prison_data.fetch(prison_name).fetch(:nomis_id)
+    template_path = Rails.root.join('app', 'views', 'content')
+    candidates = [
+      "_id_#{nomis_id}.md",
+      '_standard_id_requirements.md'
+    ].map { |filename| template_path.join(filename) }
+    File.read(candidates.find { |path| File.exist?(path) })
   end
 
   def weeks_start

--- a/app/views/content/_confirmation_page.md
+++ b/app/views/content/_confirmation_page.md
@@ -7,7 +7,7 @@ Follow these steps if you don't get an email to confirm your visit within 3 work
 
 ## <a name="#info-id-requirements"></a> ID you need for each visit
 
-<%= render partial: 'content/id_requirements', locals: { output_format: :html } %>
+<%= render partial: 'content/id_requirements' %>
 
 If you have any questions about ID requirements, please contact the prison.
 

--- a/app/views/content/_id_requirements.html.erb
+++ b/app/views/content/_id_requirements.html.erb
@@ -1,0 +1,1 @@
+<%= markdown(prison_specific_id_requirements(visit.prisoner.prison_name)) %>

--- a/app/views/content/_id_requirements.text.erb
+++ b/app/views/content/_id_requirements.text.erb
@@ -1,0 +1,1 @@
+<%= prison_specific_id_requirements(visit.prisoner.prison_name) %>

--- a/app/views/mailers_common/_booking_confirmation.html.haml
+++ b/app/views/mailers_common/_booking_confirmation.html.haml
@@ -83,7 +83,7 @@
 %h1{ style: 'margin:1em 0;font: bold 24px Helvetica, Arial, sans-serif' } What to bring when you visit
 
 %div{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' }
-  = render partial: 'content/id_requirements', locals: { output_format: :html }
+  = render partial: 'content/id_requirements'
 
 %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } If you have any questions about ID requirements, please contact the prison.
 

--- a/app/views/mailers_common/_booking_confirmation.text.erb
+++ b/app/views/mailers_common/_booking_confirmation.text.erb
@@ -74,7 +74,7 @@ To stop visit confirmation emails going to your spam or junk folder please add n
 What to bring when you visit
 ----------------------------
 
-<%= render partial: 'content/id_requirements', locals: { output_format: :text } %>
+<%= render partial: 'content/id_requirements' %>
 
 If you have any questions about ID requirements, please contact the prison.
 

--- a/config/initializers/markdown_handler.rb
+++ b/config/initializers/markdown_handler.rb
@@ -4,14 +4,7 @@ class MarkdownTemplateHandler
     source = erb.call(template)
     <<-SOURCE
     renderer = ::Redcarpet::Render::HTML.new(hard_wrap: true)
-    options = {
-      autolink: true,
-      no_intra_emphasis: true,
-      fenced_code_blocks: true,
-      lax_html_blocks: true,
-      strikethrough: true,
-      superscript: true
-    }
+    options = Rails.application.config.redcarpet_markdown_options
     ::Redcarpet::Markdown.new(renderer, options).render(begin;#{source};end).html_safe
     SOURCE
   end

--- a/config/initializers/redcarpet.rb
+++ b/config/initializers/redcarpet.rb
@@ -1,0 +1,8 @@
+Rails.application.config.redcarpet_markdown_options = {
+  autolink: true,
+  no_intra_emphasis: true,
+  fenced_code_blocks: true,
+  lax_html_blocks: true,
+  strikethrough: true,
+  superscript: true
+}

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -66,4 +66,26 @@ describe ApplicationHelper do
     phone = 12345
     helper.conditional_text(phone, "call ", " or").should == "call 12345 or"
   end
+
+  describe 'markdown' do
+    it 'changes markdown to HTML' do
+      source = <<-END.strip_heredoc
+        para
+
+        * list
+        * item
+      END
+      expect(markdown(source)).to match(
+        %r{\A
+          <p>\s*para\s*</p>\s*
+          <ul>\s*<li>\s*list\s*</li>\s*<li>\s*item\s*</li>\s*</ul>\s*
+        \z}x
+      )
+    end
+
+    it 'strips arbitrary HTML from input' do
+      source = "<blink>It's alive!</blink>"
+      expect(markdown(source)).not_to match(/<blink/)
+    end
+  end
 end

--- a/spec/helpers/visit_helper_spec.rb
+++ b/spec/helpers/visit_helper_spec.rb
@@ -85,37 +85,17 @@ describe VisitHelper do
     helper.prison_names.first.should == "Acklington"
   end
 
-  it "should render custom id content for certain prisons" do
-    ['Wymott',
-     'Coldingley',
-     'Cardiff',
-     'Portland',
-     'Channings Wood',
-     'Dartmoor',
-     'Sudbury',
-     'Moorland Closed',
-     'Nottingham',
-     'Glen Parva',
-     'Huntercombe',
-     'Leicester',
-     'Hindley',
-     'Norwich (A, B, C, E, M only)',
-     'Norwich (F, G, H, L only)',
-     'Norwich (Britannia House)',
-     'High Down',
-     'Highpoint North',
-     'Highpoint South'
-    ].each do |prison_name|
-      helper.custom_id_requirements(prison_name, :html).should_not be_nil
-      helper.custom_id_requirements(prison_name, :text).should_not be_nil
+  describe 'prison_specific_id_requirements' do
+    it 'should render custom id content for prisons that have it' do
+      requirements = helper.prison_specific_id_requirements('Wymott')
+      expect(requirements).to match(/tenancy agreement/)
     end
-    helper.custom_id_requirements('Rochester', :html).should be_nil
-    helper.custom_id_requirements('Rochester', :text).should be_nil
-  end
 
-  it "should render standard id requirements" do
-    helper.standard_id_requirements(:html).should_not be_nil
-    helper.standard_id_requirements(:text).should_not be_nil
+    it 'should render standard id content for prisons that do not have custom content' do
+      requirements = helper.prison_specific_id_requirements('Rochester')
+      expect(requirements).not_to match(/tenancy agreement/)
+      expect(requirements).to match(/driving licence/)
+    end
   end
 
   it "provides the date of Monday in the current week" do


### PR DESCRIPTION
The use of `lookup_context` is highly dependent on the internal workings of Rails, and makes it hard to upgrade to Rails 4.2.

We replace this with a more explicit method:

* Find the template (either specific or generic) on disk
* Return its content
* Render as Markdown if appropriate, using separate text and HTML templates
