### PR TITLE
Ensure datepicker specs run after 2015/06/09

### DIFF
--- a/app/views/deferred/slots/edit.html.haml
+++ b/app/views/deferred/slots/edit.html.haml
@@ -8,7 +8,7 @@
     %p You need to select a date and time for your visit.
 
 
-.SlotPicker
+.SlotPicker{ :"data-today" => Date.today }
 
   .right-column.visible--js-enabled
 

--- a/app/views/instant/slots/edit.html.haml
+++ b/app/views/instant/slots/edit.html.haml
@@ -8,7 +8,7 @@
     %p You need to select a date and time for your visit.
 
 
-.SlotPicker
+.SlotPicker{ :"data-today" => Date.today }
 
   .right-column.visible--js-enabled
 

--- a/spec/features/datepicker_spec.rb
+++ b/spec/features/datepicker_spec.rb
@@ -3,6 +3,14 @@ require 'browserstack_helper'
 RSpec.feature "visitor selects a date" do
   include_examples "feature helper"
 
+  before :all do
+    Timecop.travel(Time.now.next_week(:tuesday).at_noon)
+  end
+
+  after :all do
+    Timecop.return
+  end
+
   before :each do
     allow_any_instance_of(VisitController).to receive(:metrics_logger).and_return(MockMetricsLogger.new)
     allow_any_instance_of(EmailValidator).to receive(:validate_dns_records)
@@ -19,12 +27,9 @@ RSpec.feature "visitor selects a date" do
     end
 
     scenario 'Choosing a date in the past' do
-      # A Tuesday, so that yesterday is a working day
-      Timecop.travel(Time.new(2015, 6, 9, 12))
       yesterday = Time.now - 1.day
       find(:css, yesterday.strftime("a.BookingCalendar-dateLink[data-date='%Y-%m-%d']")).click
       expect(page).to have_content("It is not possible to book a visit in the past.")
-      Timecop.return
     end
 
     scenario 'Choosing a date more than 3 working days from now' do
@@ -75,12 +80,9 @@ RSpec.feature "visitor selects a date" do
     end
 
     scenario 'Choosing a date in the past' do
-      # A Tuesday, so that yesterday is a working day
-      Timecop.travel(Time.new(2015, 6, 9, 12))
       yesterday = Time.now - 1.day
       find(:css, yesterday.strftime("a.BookingCalendar-dateLink[data-date='%Y-%m-%d']")).click
       expect(page).to have_content("It is not possible to book a visit in the past.")
-      Timecop.return
     end
 
     scenario 'Choosing a date more than 3 working days from now' do


### PR DESCRIPTION
`datepicker_spec` `Choosing a date in the past` failed for two reasons:

- The `Timecop.travel` call was *after* the page was rendered, so had no impact on the rendering.
- Travelling to the past resulted in cookies that expired in the past being issued to the test browser. Because the test browser doesn't respect our time-travelling, it considered these cookies expired instantly.

To avoid the session expiring, we should always travel to a suitable date in the future (a Tuesday, so we can test booking a prior working day of the week).

Also ensure we pass the server's idea of “today” to the JavaScript to avoid weird miscalculations of end-dates on the client-side.