### PR TITLE
Update redcarpet to avoid CVE-2015-5147

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.2)
-    redcarpet (3.2.3)
+    redcarpet (3.3.2)
     request_store (1.1.0)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)


### PR DESCRIPTION
[CVE-2015-5147](https://security-tracker.debian.org/tracker/CVE-2015-5147) allows a stack overflow in header_anchor. That's bad. Don't allow that.