### PR TITLE
Adds PRY

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,8 @@ gem 'curb'
 
 group :test, :development do
   gem 'rspec-rails'
-  gem 'byebug'
+  gem 'pry-byebug'
+  gem 'pry-rails'
   gem 'timecop'
   gem 'rubyzip'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.0)
     builder (3.2.2)
-    byebug (5.0.0)
+    byebug (4.0.5)
       columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
@@ -69,6 +69,7 @@ GEM
       nokogiri (~> 1.6)
       version_sorter (~> 1.1)
     cliver (0.3.2)
+    coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -121,6 +122,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
@@ -137,6 +139,15 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -219,6 +230,7 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    slop (3.6.0)
     sprockets (3.2.0)
       rack (~> 1.0)
     sprockets-rails (2.3.1)
@@ -258,7 +270,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   capybara
   chromedriver-helper
   coffee-rails
@@ -274,6 +285,8 @@ DEPENDENCIES
   pg
   poltergeist
   prison_staff_info!
+  pry-byebug
+  pry-rails
   rails
   redcarpet
   rspec-html-matchers
@@ -290,3 +303,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   zendesk_api
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
- adds pry as a runtime developer console & keeps byebug functionality.
- pry-rails enables `rails c` to start up in a pry session.

http://pryrepl.org
https://github.com/deivid-rodriguez/pry-byebug
https://github.com/rweng/pry-rails