### PR TITLE
Enable mailer previews in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,4 +22,6 @@ PrisonVisits2::Application.configure do
   config.assets.debug = true
 
   config.action_mailer.default_url_options = { host: "localhost", protocol: "http", port: "3000" }
+
+  config.action_mailer.preview_path = "#{Rails.root}/test/mailers/previews"
 end


### PR DESCRIPTION
Enables mail previews to be displayed when visiting `/rails/mailers` in development mode.

**N.B.** Mailer previews did appear to have worked at some point in the past for this project.

<img width="450" alt="mail_previews_example" src="https://cloud.githubusercontent.com/assets/1006365/8672047/666a41ce-2a22-11e5-8cf7-1c0440c6fef0.png">
