### PR TITLE
Fixes missing `prison_name` on prisoner-details page

### DIFF
--- a/app/helpers/visit_helper.rb
+++ b/app/helpers/visit_helper.rb
@@ -13,6 +13,10 @@ module VisitHelper
     end
   end
 
+  def prison_name
+    visit.prisoner.prison_name
+  end
+
   def prison_names
     Rails.configuration.prison_data.keys.sort
   end

--- a/spec/features/prison_information_page_spec.rb
+++ b/spec/features/prison_information_page_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature 'visitor entering prisoner information' do
         context 'when a prison is not selected' do
           it 'displays an error message' do
             click_button 'Continue'
-            expect(page).to have_css("label[for='prisoner_prison_name'] .validation-message")
+
+            expect(page).to have_css "label[for='prisoner_prison_name'] .validation-message"
           end
         end
 
@@ -21,14 +22,49 @@ RSpec.feature 'visitor entering prisoner information' do
           it 'displays error messages for each field' do
             set_prison_to 'Cardiff'
             click_button 'Continue'
+
             prisoner_element_ids.each do |id|
               expect(page).to have_css ".validation-error #prisoner_#{id}"
             end
           end
         end
+
+        context 'when a prison that is disabled is selected' do
+          let(:a_disabled_prison) { 'Rye Hill' }
+
+          it 'displays a message about the prison being disabled' do
+            set_prison_to a_disabled_prison
+            click_button 'Continue'
+
+            expect(page).to have_content 'HMP Rye Hill is unable to process online visit requests.'
+          end
+        end
+
+        context 'when a prison is coming soon' do
+          let(:a_prison_coming_soon) { 'Hull' }
+
+          it 'displays a message about the prison not being available just yet' do
+            set_prison_to a_prison_coming_soon
+            click_button 'Continue'
+
+            expect(page).to have_content 'HMP Hull isn’t able to process online visit requests yet.'
+          end
+        end
+
+        context 'when a prison has IT issues' do
+          let(:a_prison_with_it_issues) { 'Blantyre House' }
+
+          it 'displays a message about the prison not being available just yet' do
+            set_prison_to a_prison_with_it_issues
+            click_button 'Continue'
+
+            expect(page).
+              to have_content 'HMP Blantyre House is unable to process online visit requests right now.'
+          end
+        end
       end
 
-      scenario 'user is taken to the vistor page when information is entered correctly' do
+      scenario 'a user is taken to the vistor page when information is entered correctly' do
         enter_prisoner_information(flow)
 
         expect(page).to have_content('Visitor 1')

--- a/spec/features/prison_information_page_spec.rb
+++ b/spec/features/prison_information_page_spec.rb
@@ -1,42 +1,38 @@
 require 'browserstack_helper'
 
-RSpec.feature "visitor enters prisoner information" do
-  include_examples "feature helper"
+RSpec.feature 'visitor entering prisoner information' do
+  include_examples 'feature helper'
 
-  [:deferred, :instant].each do |flow|
-    context "#{flow} flow" do
+  before(:each) { visit '/prisoner-details' }
 
-
-      context "and leaves fields blank" do
-        it "validation messages are present when a prison is not selected" do
-          visit '/prisoner-details'
-
-          click_button 'Continue'
-
-          expect(page).to have_css("label[for='prisoner_prison_name'] .validation-message")
+  %i<deferred instant>.each do |flow|
+    describe "#{flow} flow" do
+      describe 'page validations' do
+        context 'when a prison is not selected' do
+          it 'displays an error message' do
+            click_button 'Continue'
+            expect(page).to have_css("label[for='prisoner_prison_name'] .validation-message")
+          end
         end
 
-        it "validation messages are present" do
-          visit '/prisoner-details'
+        context 'when prisoner related form fields are left blank' do
+          let(:prisoner_element_ids) { %w<first_name last_name date_of_birth_3i number> }
 
-          find(:css, ".ui-autocomplete-input").set('Cardiff')
-          click_button 'Continue'
-
-          expect(page).to have_css(".validation-error #prisoner_first_name")
-          expect(page).to have_css(".validation-error #prisoner_last_name")
-          expect(page).to have_css(".validation-error #prisoner_date_of_birth_3i")
-          expect(page).to have_css(".validation-error #prisoner_number")
+          it 'displays error messages for each field' do
+            set_prison_to 'Cardiff'
+            click_button 'Continue'
+            prisoner_element_ids.each do |id|
+              expect(page).to have_css ".validation-error #prisoner_#{id}"
+            end
+          end
         end
       end
 
-      context "and they fill out all fields" do
-        it "prompts for visitor information" do
-          visit '/prisoner-details'
+      scenario 'user is taken to the vistor page when information is entered correctly' do
+        enter_prisoner_information(flow)
 
-          enter_prisoner_information(flow)
-
-          expect(page).to have_content('Visitor 1')
-        end
+        expect(page).to have_content('Visitor 1')
+        expect(page.current_path).to eq "/#{flow}/visitors"
       end
     end
   end

--- a/spec/helpers/visit_helper_spec.rb
+++ b/spec/helpers/visit_helper_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe VisitHelper, type: :helper do
       expect(helper.current_slots).to eq(["2014-05-12-1045-1345"])
     end
 
+    it 'provides the prisons name' do
+      expect(helper.prison_name).to eq('Rochester')
+    end
+
     it "provides the phone number" do
       expect(helper.prison_phone).to eq("01634 803100")
     end

--- a/spec/support/features_helper.rb
+++ b/spec/support/features_helper.rb
@@ -47,6 +47,10 @@ module FeaturesHelper
       end
     end
   end
+
+  def set_prison_to(prison_name)
+    find(:css, ".ui-autocomplete-input").set(prison_name)
+  end
 end
 
 shared_examples "feature helper" do


### PR DESCRIPTION
The `prison_name` helper method had accidentally been removed from the codebase in #213 and was causing errors when trying to render templates that require it - specifically when displaying reasons why a user cannot make a booking with a prison.

- Adds it back in with a test
- Adds a number of tests to the `/prisoner` page feature asserting the different error messages a user receives for different prison states (disabled, coming soon, IT issues)
- Refactors the feature test slightly to make it a bit more readable

<img width="552" alt="screen shot 2015-07-24 at 16 53 04" src="https://cloud.githubusercontent.com/assets/1006365/8878712/7d0d4bec-3224-11e5-9b1b-d5aa8d8b08a1.png">
