### PR TITLE
Remove extraneous white space on single digit dates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
 
   def format_day(date)
     date = Date.parse(date) if date.class == String
-    date.strftime("%A %e %B").strip
+    date.strftime("%A %-e %B")
   end
 
   def display_start_time(times)

--- a/spec/helpers/visit_helper_spec.rb
+++ b/spec/helpers/visit_helper_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe VisitHelper, type: :helper do
     end
 
     it "provides a formatted date for when a response may be sent out" do
-      expect(helper.when_to_expect_reply(Date.parse("2014-10-03"))).to eq("Monday  6 October")
+      expect(helper.when_to_expect_reply(Date.parse("2014-10-03"))).to eq("Monday 6 October")
     end
   end
 

--- a/spec/mailers/visitor_mailer_spec.rb
+++ b/spec/mailers/visitor_mailer_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe VisitorMailer do
         expect(email[:to]).to eq(visitor_address)
         expect(email).not_to match_in_html("Jimmy Harris")
         expect(email).to match_in_html(visit_status_url(id: sample_visit.visit_id))
-        expect(email).to match_in_html("by Friday  5 July to")
+        expect(email).to match_in_html("by Friday 5 July to")
 
         expect(email).to match_in_html(sample_visit.visit_id)
         expect(email).to match_in_text(sample_visit.visit_id)


### PR DESCRIPTION
Changes the date format used by `strftime` to eliminate
date padding on single digit numerical output.

Refer to http://ruby-doc.org/core-2.2.2/Time.html#method-i-strftime
for more info.

- Before: Thursday  3 June
- After: Thursday 3 June

Double digit dates worked originally and will continue to
work as expected.