### PR TITLE
Correct the order for 'bottom' leaderboard rankings

### DIFF
--- a/lib/leaderboard_report.rb
+++ b/lib/leaderboard_report.rb
@@ -51,7 +51,7 @@ GROUP BY nomis_id
   end
 
   def bottom(n)
-    JSONPresenter.new(ranked_performance.last(n))
+    JSONPresenter.new(ranked_performance.last(n).reverse)
   end
 
   class JSONPresenter


### PR DESCRIPTION
This ensures that the list returned from the `leaderboard`
endpoint in the `GeckoboardController` is presented in the 
correct order.

The head of the list will now yield the worst performer with
each consecutive element improving.

Prior to this fix the list was returned in descending
performance order(the worst performer would be the 10th element).