### PR TITLE
Re-enable anomalous prison slots on bank holidays

### DIFF
--- a/lib/prison_day.rb
+++ b/lib/prison_day.rb
@@ -6,7 +6,7 @@ class PrisonDay < Struct.new(:date, :prison)
   end
 
   def visiting_day?
-    non_blocked_day? && non_holiday? && available_day?
+    non_blocked_day? && available_day?
   end
 
   private
@@ -31,7 +31,7 @@ class PrisonDay < Struct.new(:date, :prison)
   end
 
   def visiting_slot?
-    visiting_slot_days.include? abbreviated_day_name
+    non_holiday? && visiting_slot_days.include?(abbreviated_day_name)
   end
 
   def available_day?

--- a/spec/lib/prison_day_spec.rb
+++ b/spec/lib/prison_day_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe PrisonDay do
         subject { described_class.new bank_holiday_friday, prison_from(prison_data) }
 
         specify { expect(subject.visiting_day?).to be false }
+
+        context 'and has an anomalous booking slot' do
+          subject { described_class.new(
+            bank_holiday_friday,
+            prison_from(prison_data.merge(
+              slot_anomalies: {bank_holiday_friday => ["0930-1000"]}
+            ))
+          )}
+
+          specify { expect(subject.visiting_day?).to be true }
+        end
       end
 
       context 'and is an unbookable date' do


### PR DESCRIPTION
In the move to the new PrisonSchedule system (3dcea63), we lost the ability to have anomalous prison slots on bank holidays.

To fix this, we only want to consider the holiday-ness of a day when evaluating if the day has “normal” visiting slots.