### PR TITLE
Remove dead view for ID requirements

### DIFF
--- a/app/views/content/_id_requirements.erb
+++ b/app/views/content/_id_requirements.erb
@@ -1,5 +1,0 @@
-<% if requirements = custom_id_requirements(visit.prisoner.prison_name, output_format) %>
-<%= requirements %>
-<% else %>
-<%= standard_id_requirements(output_format) %>
-<% end %>


### PR DESCRIPTION
This file is not being used `since standard_id_requirements` and `custom_id_requirements` [methods were removed](https://github.com/ministryofjustice/prison-visits/pull/214).