### PR TITLE
Fix calculation of confirmation date

### DIFF
--- a/lib/prison_day.rb
+++ b/lib/prison_day.rb
@@ -2,11 +2,11 @@ class PrisonDay < Struct.new(:date, :prison)
   WEEKEND_DAYS = %w<sat sun>.freeze
 
   def staff_working_day?
-    non_holiday? && working_day?
+    normal_working_day? && !holiday?
   end
 
   def visiting_day?
-    non_blocked_day? && available_day?
+    available_day?  && !blocked_day?
   end
 
   private
@@ -14,7 +14,7 @@ class PrisonDay < Struct.new(:date, :prison)
   delegate :works_everyday?, :anomalous_dates,
     :visiting_slot_days, :unbookable_dates, to: :prison
 
-  def working_day?
+  def normal_working_day?
     works_everyday? ? true : weekday?
   end
 
@@ -22,8 +22,8 @@ class PrisonDay < Struct.new(:date, :prison)
     WEEKEND_DAYS.exclude? abbreviated_day_name
   end
 
-  def non_holiday?
-    Rails.configuration.bank_holidays.exclude? date
+  def holiday?
+    Rails.configuration.bank_holidays.include?(date)
   end
 
   def anomalous_day?
@@ -31,15 +31,15 @@ class PrisonDay < Struct.new(:date, :prison)
   end
 
   def visiting_slot?
-    non_holiday? && visiting_slot_days.include?(abbreviated_day_name)
+    visiting_slot_days.include?(abbreviated_day_name) && !holiday?
   end
 
   def available_day?
     visiting_slot? || anomalous_day?
   end
 
-  def non_blocked_day?
-    unbookable_dates.exclude? date
+  def blocked_day?
+    unbookable_dates.include?(date)
   end
 
   def abbreviated_day_name

--- a/lib/prison_schedule.rb
+++ b/lib/prison_schedule.rb
@@ -7,21 +7,17 @@ class PrisonSchedule < Struct.new(:prison)
   end
 
   def available_visitation_dates
-    available_visitation_range.reduce([]) do |valid_dates, day|
-      valid_dates.tap do |dates|
-        dates << day if PrisonDay.new(day, prison).visiting_day?
-      end
-    end
+    available_visitation_range.select { |day|
+      PrisonDay.new(day, prison).visiting_day?
+    }
   end
 
   private
 
   def staff_working_days
-    Enumerator.new do |y|
-      confirmation_email_range.each do |day|
-        y << day if PrisonDay.new(day, prison).staff_working_day?
-      end
-    end
+    confirmation_email_range.select { |day|
+      PrisonDay.new(day, prison).staff_working_day?
+    }
   end
 
   def confirmation_email_range

--- a/lib/prison_schedule.rb
+++ b/lib/prison_schedule.rb
@@ -3,7 +3,11 @@ class PrisonSchedule < Struct.new(:prison)
   delegate :days_lead_time, :booking_window, to: :prison
 
   def confirmation_email_date
-    staff_working_days.take(prison_processing_days).last
+    if days_lead_time.zero?
+      staff_working_days.first
+    else
+      staff_working_days.take(days_lead_time).last
+    end
   end
 
   def available_visitation_dates
@@ -31,10 +35,5 @@ class PrisonSchedule < Struct.new(:prison)
 
   def last_bookable_day
     booking_window.days.from_now.to_date
-  end
-
-  def prison_processing_days
-    # increment the value as `#take` on a range is not zero based
-    days_lead_time.next
   end
 end


### PR DESCRIPTION
Previously, the system calculated the confirmation date as the working day after the lead time. It should be the last day of the lead time.

For example, if a prison processes visits Monday to Friday, and Saturday is a visiting day, then it should be possible to book a visit for the coming Saturday:

    Tuesday   | Make booking
    Wednesday | Processing
    Thursday  | Processing
    Friday    | Processing & Confirmation
    Saturday  | Visit

Previously, because of the extra day, the confirmation would not be sent until Monday, and visits would not be possible until Tuesday.

See https://www.pivotaltracker.com/story/show/101219102
