### PR TITLE
Send email and tickets outside the main request-response cycle

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -4,10 +4,6 @@ class HealthcheckController < ApplicationController
   def index
     healthcheck = Healthcheck.new
     status = healthcheck.ok? ? nil : :bad_gateway
-    render status: status,
-      json: {
-        checks: healthcheck.checks,
-        queues: healthcheck.queues
-      }
+    render status: status, json: healthcheck.checks
   end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,33 +2,12 @@ class HealthcheckController < ApplicationController
   permit_only_with_key
 
   def index
-    checks = {
-      sendgrid: sendgrid_alive?,
-      messagelabs: messagelabs_alive?,
-      database: database_active?,
-      zendesk: zendesk_alive?
-    }
-    status = :bad_gateway unless checks.values.all?
-    render status: status, json: { checks: checks }
-  end
-
-  private
-
-  def sendgrid_alive?
-    SendgridApi.smtp_alive?(*VisitorMailer.smtp_settings.values_at(:address, :port))
-  end
-
-  def messagelabs_alive?
-    SendgridApi.smtp_alive?(*PrisonMailer.smtp_settings.values_at(:address, :port))
-  end
-
-  def database_active?
-    ActiveRecord::Base.connection.active?
-  rescue PG::ConnectionBad
-    false
-  end
-
-  def zendesk_alive?
-    ZENDESK_CLIENT.tickets.count >= 0
+    healthcheck = Healthcheck.new
+    status = healthcheck.ok? ? nil : :bad_gateway
+    render status: status,
+      json: {
+        checks: healthcheck.checks,
+        queues: healthcheck.queues
+      }
   end
 end

--- a/app/services/healthcheck.rb
+++ b/app/services/healthcheck.rb
@@ -45,7 +45,7 @@ class Healthcheck
       oldest: oldest(q),
       count: q.count
     }
-  rescue Exception
+  rescue StandardError
     { description: description, ok: false, oldest: nil, count: 0 }
   end
 
@@ -60,7 +60,7 @@ class Healthcheck
 
   def database_active?
     ActiveRecord::Base.connection.active?
-  rescue Exception
+  rescue StandardError
     false
   end
 end

--- a/app/services/healthcheck.rb
+++ b/app/services/healthcheck.rb
@@ -1,0 +1,60 @@
+require 'sidekiq/api'
+
+class Healthcheck
+  STALENESS_THRESHOLD = 10.minutes
+
+  def initialize
+    @queues = {}
+  end
+
+  def ok?
+    checks.values.all?
+  end
+
+  def checks
+    {
+      database: database_active?,
+      mailers: !old_items?(queue('mailers')),
+      zendesk: !old_items?(queue('zendesk'))
+    }
+  end
+
+  def queues
+    {
+      mailers: queue_info(queue('mailers')),
+      zendesk: queue_info(queue('zendesk')),
+    }
+  end
+
+  private
+
+  def queue(name)
+    @queues[name] ||= Sidekiq::Queue.new(name)
+  end
+
+  def queue_info(q)
+    {
+      oldest: oldest_item_created_at(q),
+      count: q.count
+    }
+  end
+
+  def oldest_item_created_at(q)
+    q.any? ? q.first.created_at : nil
+  end
+
+  def old_items?(q)
+    created_at = oldest_item_created_at(q)
+    if created_at
+      created_at < STALENESS_THRESHOLD.ago
+    else
+      false
+    end
+  end
+
+  def database_active?
+    ActiveRecord::Base.connection.active?
+  rescue PG::ConnectionBad
+    false
+  end
+end

--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -1,7 +1,7 @@
 class SendgridApi
   extend SingleForwardable
 
-  def_single_delegators :new, :spam_reported?, :bounced?, :smtp_alive?
+  def_single_delegators :new, :spam_reported?, :bounced?
 
   def spam_reported?(email)
     return false unless can_access_sendgrid?
@@ -14,17 +14,6 @@ class SendgridApi
     return false unless can_access_sendgrid?
     bounces.retrieve(email: email).any?
   rescue JSON::ParserError, SendgridToolkit::APIError
-    false
-  end
-
-  def smtp_alive?(host, port)
-    Net::SMTP.start(host, port) do |smtp|
-      smtp.enable_starttls_auto
-      smtp.ehlo(Socket.gethostname)
-      smtp.finish
-    end
-    true
-  rescue StandardError
     false
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,4 +30,6 @@ PrisonVisits2::Application.configure do
   config.action_mailer.default_url_options = { host: "localhost", protocol: "http", port: "3000" }
 
   config.action_mailer.preview_path = "#{Rails.root}/test/mailers/previews"
+
+  Rails.application.config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,6 @@ PrisonVisits2::Application.configure do
   config.logstasher.logger_path = File.join(Rails.root, "log", "logstash_production.json")
 
   config.action_mailer.default_url_options = { host: ENV["SERVICE_URL"] || (raise "Missing SERVICE_URL"), protocol: "https" }
+
+  Rails.application.config.active_job.queue_adapter = :sidekiq
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:queues:
+  - default
+  - mailers
+  - zendesk

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -16,28 +16,24 @@ RSpec.describe HealthcheckController, type: :controller do
     JSON.parse(response.body)
   }
 
-  let(:message_labs_address) { double }
-  let(:message_labs_port) { double }
-  let(:sendgrid_address) { double }
-  let(:sendgrid_port) { double }
+  let(:healthcheck) {
+    double(
+      Healthcheck,
+      ok?: true,
+      checks: {
+        database: true,
+        mailers: true,
+        zendesk: true
+      },
+      queues: {
+        mailers: { oldest: nil, count: 0 },
+        zendesk: { oldest: nil, count: 0 }
+      }
+    )
+  }
 
   before do
-    allow(SendgridApi).to receive(:smtp_alive?).and_return(true)
-    allow(ZENDESK_CLIENT).to receive(:tickets).and_return(double(count: 0))
-  end
-
-  shared_examples 'a service is broken' do |service|
-    before do
-      get :index, key: key
-    end
-
-    it 'returns an HTTP Bad Gateway status' do
-      expect(response).to have_http_status(:bad_gateway)
-    end
-
-    it "reports #{service} as inaccessible" do
-      expect(parsed_body).to include('checks' => include(service => false))
-    end
+    allow(Healthcheck).to receive(:new).and_return(healthcheck)
   end
 
   context 'with an invalid key' do
@@ -57,80 +53,68 @@ RSpec.describe HealthcheckController, type: :controller do
       expect(response).to be_success
     end
 
-    it 'reports sendgrid as OK' do
-      expect(parsed_body).to include('checks' => include('sendgrid' => true))
-    end
-
-    it 'reports messagelabs as OK' do
-      expect(parsed_body).to include('checks' => include('messagelabs' => true))
-    end
-
-    it 'reports database as OK' do
-      expect(parsed_body).to include('checks' => include('database' => true))
-    end
-
-    it 'reports zendesk as OK' do
-      expect(parsed_body).to include('checks' => include('zendesk' => true))
+    it 'reports services as OK' do
+      expect(parsed_body).to include(
+        'checks' => {
+          'mailers' => true,
+          'database' => true,
+          'zendesk' => true
+        }
+      )
     end
   end
 
-  context 'when messagelabs is down' do
+  context 'when the healthcheck is not OK' do
     before do
-      address = double
-      port = double
-      allow(PrisonMailer).
-        to receive(:smtp_settings).
-        and_return(address: address, port: port)
-      allow(SendgridApi).
-        to receive(:smtp_alive?).
-        with(address, port).
-        and_return(false)
+      allow(healthcheck).to receive(:ok?).and_return(false)
+      get :index, key: key
     end
 
-    it_behaves_like 'a service is broken', 'messagelabs'
+    it 'returns an HTTP Bad Gateway status' do
+      expect(response).to have_http_status(:bad_gateway)
+    end
   end
 
-  context 'when sendgrid is down' do
+  context 'when there are no queue items' do
     before do
-      address = double
-      port = double
-      allow(VisitorMailer).
-        to receive(:smtp_settings).
-        and_return(address: address, port: port)
-      allow(SendgridApi).
-        to receive(:smtp_alive?).
-        with(address, port).
-        and_return(false)
+      get :index, key: key
     end
 
-    it_behaves_like 'a service is broken', 'sendgrid'
+    it 'reports empty queue statuses' do
+      expect(parsed_body).to include(
+        'queues' => {
+          'mailers' => { 'oldest' => nil, 'count' => 0 },
+          'zendesk' => { 'oldest' => nil, 'count' => 0 }
+        }
+      )
+    end
   end
 
-  context 'when the database is down' do
+  context 'when there are queue items' do
+    let(:mq_created_at) { Time.at(1440685647).utc }
+    let(:zq_created_at) { Time.at(1440685724).utc }
+
     before do
-      allow(ActiveRecord::Base.connection).
-        to receive(:active?).
-        and_return(false)
+      allow(healthcheck).to receive(:queues).and_return(
+        mailers: { oldest: mq_created_at, count: 1 },
+        zendesk: { oldest: zq_created_at, count: 2 }
+      )
+      get :index, key: key
     end
 
-    it_behaves_like 'a service is broken', 'database'
-  end
-
-  context 'when the database is off' do
-    before do
-      allow(ActiveRecord::Base.connection).
-        to receive(:active?).
-        and_raise(PG::ConnectionBad)
+    it 'reports empty queue statuses' do
+      expect(parsed_body).to include(
+        'queues' => {
+          'mailers' => {
+            'oldest' => '2015-08-27T14:27:27.000Z',
+            'count' => 1
+          },
+          'zendesk' => {
+            'oldest' => '2015-08-27T14:28:44.000Z',
+            'count' => 2
+          }
+        }
+      )
     end
-
-    it_behaves_like 'a service is broken', 'database'
-  end
-
-  context 'when Zendesk is inaccessible' do
-    before do
-      allow(ZENDESK_CLIENT).to receive(:tickets).and_return(double(count: -1))
-    end
-
-    it_behaves_like 'a service is broken', 'zendesk'
   end
 end

--- a/spec/services/healthcheck_spec.rb
+++ b/spec/services/healthcheck_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck do
+  subject { described_class.new }
+
+  let(:mailers_queue) { [] }
+  let(:zendesk_queue) { [] }
+
+  before do
+    allow(Sidekiq::Queue).
+      to receive(:new).
+      with('mailers').
+      and_return mailers_queue
+    allow(Sidekiq::Queue).
+      to receive(:new).
+      with('zendesk').
+      and_return zendesk_queue
+  end
+
+  context 'when everything is OK' do
+    context 'with empty queues' do
+      it { is_expected.to be_ok }
+
+      it 'reports all checks as true' do
+        expect(subject.checks).to eq(
+          database: true,
+          mailers: true,
+          zendesk: true
+        )
+      end
+
+      it 'reports the queue status' do
+        expect(subject.queues).to eq(
+          mailers: { oldest: nil, count: 0 },
+          zendesk: { oldest: nil, count: 0 }
+        )
+      end
+    end
+
+    context 'with only fresh queue items' do
+      let(:mq_created_at) { 9.minutes.ago }
+      let(:zq_created_at) { 8.minutes.ago }
+      let(:mailers_queue) {
+        [double(Sidekiq::Job, created_at: mq_created_at)]
+      }
+      let(:zendesk_queue) {
+        [double(Sidekiq::Job, created_at: zq_created_at)]
+      }
+
+      it { is_expected.to be_ok }
+
+      it 'reports all checks as true' do
+        expect(subject.checks).to eq(
+          database: true,
+          mailers: true,
+          zendesk: true
+        )
+      end
+
+      it 'reports the queue status' do
+        expect(subject.queues).to eq(
+          mailers: { oldest: mq_created_at, count: 1 },
+          zendesk: { oldest: zq_created_at, count: 1 }
+        )
+      end
+    end
+  end
+
+  context 'when there is a problem' do
+    context 'with stale mailers queue items' do
+      let(:mq_created_at) { 11.minutes.ago }
+      let(:mailers_queue) {
+        [double(Sidekiq::Job, created_at: mq_created_at)]
+      }
+
+      it { is_expected.not_to be_ok }
+
+      it 'reports the mailers check as false' do
+        expect(subject.checks).to include(mailers: false)
+      end
+
+      it 'reports the mailers queue status' do
+        expect(subject.queues).to include(
+          mailers: { oldest: mq_created_at, count: 1 }
+        )
+      end
+    end
+
+    context 'with stale zendesk queue items' do
+      let(:zq_created_at) { 11.minutes.ago }
+      let(:zendesk_queue) {
+        [double(Sidekiq::Job, created_at: zq_created_at)]
+      }
+
+      it { is_expected.not_to be_ok }
+
+      it 'reports the zendesk check as false' do
+        expect(subject.checks).to include(zendesk: false)
+      end
+
+      it 'reports the zendesk queue status' do
+        expect(subject.queues).to include(
+          zendesk: { oldest: zq_created_at, count: 1 }
+        )
+      end
+    end
+
+    context 'with an inactive database' do
+      before do
+        allow(ActiveRecord::Base.connection).
+          to receive(:active?).
+          and_return(false)
+      end
+
+      it { is_expected.not_to be_ok }
+
+      it 'reports the database check as false' do
+        expect(subject.checks).to include(database: false)
+      end
+    end
+
+    context 'with an unreachable database' do
+      before do
+        allow(ActiveRecord::Base.connection).
+          to receive(:active?).
+          and_raise(PG::ConnectionBad)
+      end
+
+      it { is_expected.not_to be_ok }
+
+      it 'reports the database check as false' do
+        expect(subject.checks).to include(database: false)
+      end
+    end
+  end
+end

--- a/spec/services/healthcheck_spec.rb
+++ b/spec/services/healthcheck_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Healthcheck do
       before do
         allow(ActiveRecord::Base.connection).
           to receive(:active?).
-          and_raise(Exception)
+          and_raise(StandardError)
       end
 
       it_behaves_like 'everything is not OK'

--- a/spec/services/sendgrid_api_spec.rb
+++ b/spec/services/sendgrid_api_spec.rb
@@ -182,42 +182,4 @@ RSpec.describe SendgridApi do
       end
     end
   end
-
-  context 'sendgrid connection test' do
-    let :host do
-      'smtp.sendgrid.net'
-    end
-
-    let :port do
-      587
-    end
-
-    context 'when it connects' do
-      it 'will return true' do
-        expect(Net::SMTP).to receive(:start)
-        expect(subject.smtp_alive?(host, port)).to be_truthy
-      end
-    end
-
-    context 'when it times out' do
-      it 'will return false' do
-        expect(Net::SMTP).to receive(:start).and_raise(Net::OpenTimeout)
-        expect(subject.smtp_alive?(host, port)).to be_falsey
-      end
-    end
-
-    context 'when the port is closed' do
-      it 'will return false' do
-        expect(Net::SMTP).to receive(:start).and_raise(Errno::ECONNREFUSED)
-        expect(subject.smtp_alive?(host, port)).to be_falsey
-      end
-    end
-
-    context 'when the hostname cannot be resolved' do
-      it 'will return false' do
-        expect(Net::SMTP).to receive(:start).and_raise(SocketError)
-        expect(subject.smtp_alive?(host, port)).to be_falsey
-      end
-    end
-  end
 end


### PR DESCRIPTION
**DO NOT MERGE YET** – Waiting for PIA

* https://www.pivotaltracker.com/story/show/96673886
* https://www.pivotaltracker.com/story/show/96673592

Sending email is one of the main performance-limiting factors in this application. This set of commits configures the application to use Redis for queueing, with the Sidekiq adapter. The queues are configured via `config/sidekiq.yml`, and the remaining configuration can be done via the command-line as required. The default configuration expects a local instance of Redis on its default port. The queue can be consumed using the `sidekiq` executable:

```sh
$ bundle exec sidekiq
```

Now that we are going to send emails via queues, we don't actually care about transient unavailability of SMTP servers or the Zendesk API. Instead, we care how many items are on the queues, and how old they are.

In order to facilitate monitoring of this, the healthcheck response now includes queue information, and we have taken this opportunity to make the format match that of other services as in #225. It now looks like this:

```json
{
  "database": {
    "description": "Postgres database",
    "ok": true
  },
  "mailers": {
    "description": "Email queue",
    "ok": true,
    "oldest": "2015-09-04T16:06:18.173Z",
    "count": 3
  },
  "zendesk": {
    "description": "Zendesk queue",
    "ok": true,
    "oldest": "2015-09-04T16:06:18.178Z",
    "count": 1
  },
  "ok": true
}
```

The mailers and zendesk checks pass if there are no stale items in those queues, which is computed by checking whether the oldest queue item is more than ten minutes old.

See also:

* [ActiveJob](http://edgeguides.rubyonrails.org/active_job_basics.html)
* [Available backends](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html)
* [Sidekiq Wiki](https://github.com/mperham/sidekiq/wiki)