### PR TITLE
Fix CSRF protection at the ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   helper_method :visit
   before_filter :add_extra_sentry_metadata
+  protect_from_forgery with: :exception
 
   def self.permit_only_from_prisons
     before_filter :reject_untrusted_ips!

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,5 +1,4 @@
 class FeedbacksController < ApplicationController
-  protect_from_forgery
 
   def index
   end


### PR DESCRIPTION
Fix the implementation of CSFR protection at thet Application Level by
setting `protect_from_forgery with: :exception` in the
`ApplicationController`