### PR TITLE
Tests and fixes for unexpected journeys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,5 @@ group :test, :development do
   gem 'rspec-html-matchers'
   gem 'simplecov', '~> 0.7.1', require: false
   gem 'simplecov-rcov', require: false
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (6.0.3)
     builder (3.2.2)
     byebug (4.0.5)
@@ -117,6 +118,8 @@ GEM
     inflection (1.0.0)
     json (1.8.3)
     kgio (2.9.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     logstash-event (1.2.02)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -281,6 +284,7 @@ DEPENDENCIES
   elasticsearch
   govuk_frontend_toolkit (= 2.0.1)
   haml-rails
+  launchy
   logstasher!
   mail
   moj_template (= 0.21.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,4 +72,11 @@ class ApplicationController < ActionController::Base
   def metrics_logger
     METRICS_LOGGER
   end
+
+  def ensure_visit_integrity
+    unless visit && visit.prisoner && visit.prisoner.prison_name.present?
+      redirect_to edit_prisoner_details_path,
+        notice: 'You need to complete missing information to start or continue your visit request'
+    end
+  end
 end

--- a/app/controllers/deferred/slots_controller.rb
+++ b/app/controllers/deferred/slots_controller.rb
@@ -2,6 +2,7 @@ class Deferred::SlotsController < ApplicationController
   include CookieGuard
   include SessionGuard
   include SlotsManipulator
+  before_action :ensure_visit_integrity, only: [:edit, :update]
 
   def edit
     @slots = visit.slots.empty? ? [Slot.new, Slot.new, Slot.new] : visit.slots

--- a/app/controllers/deferred/visitors_details_controller.rb
+++ b/app/controllers/deferred/visitors_details_controller.rb
@@ -2,6 +2,7 @@ class Deferred::VisitorsDetailsController < ApplicationController
   include CookieGuard
   include SessionGuard
   include VisitorsManipulator
+  before_action :ensure_visit_integrity, only: [:edit, :update]
 
   def edit
     @collect_phone_number = true

--- a/app/controllers/deferred/visits_controller.rb
+++ b/app/controllers/deferred/visits_controller.rb
@@ -1,6 +1,7 @@
 class Deferred::VisitsController < ApplicationController
   include CookieGuard
   include SessionGuard
+  before_action :ensure_visit_integrity, only: [:edit, :update]
   before_filter :logstasher_add_visit_id_from_session, only: :update
 
   def update

--- a/app/controllers/instant/slots_controller.rb
+++ b/app/controllers/instant/slots_controller.rb
@@ -3,6 +3,7 @@ class Instant::SlotsController < ApplicationController
   include SessionGuard
   include KillswitchGuard
   include SlotsManipulator
+  before_action :ensure_visit_integrity, only: [:edit, :update]
 
   def edit
     @slots = visit.slots.empty? ? [Slot.new] : visit.slots

--- a/app/controllers/instant/visitors_details_controller.rb
+++ b/app/controllers/instant/visitors_details_controller.rb
@@ -3,6 +3,7 @@ class Instant::VisitorsDetailsController < ApplicationController
   include SessionGuard
   include KillswitchGuard
   include VisitorsManipulator
+  before_action :ensure_visit_integrity, only: [:edit, :update]
 
   def edit
     @collect_phone_number = false

--- a/app/controllers/instant/visits_controller.rb
+++ b/app/controllers/instant/visits_controller.rb
@@ -2,6 +2,7 @@ class Instant::VisitsController < ApplicationController
   include CookieGuard
   include SessionGuard
   include KillswitchGuard
+  before_action :ensure_visit_integrity, only: [:edit, :update]
   before_filter :logstasher_add_visit_id_from_session, only: :update
 
   def update

--- a/app/views/deferred/slots/edit.html.haml
+++ b/app/views/deferred/slots/edit.html.haml
@@ -82,9 +82,9 @@
         = f.fields_for :slots, slot do
 
           .group
-            %label Option #{index+1}
+            %label{ for: "visit_slot_#{index+1}" } Option #{index+1}
 
-            %select.SlotPicker-input(name='visit[slots][][slot]')
+            %select.SlotPicker-input(name='visit[slots][][slot]'){ id: "visit_slot_#{index+1}" }
               %option(value='') none
               - @schedule.available_visitation_dates.each do |date|
                 - slots_for_day(date).each do |slot|

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,9 @@
 SERVICE_DOMAIN = (url = ENV['SERVICE_URL']) ? URI.parse(url).host : nil
 
-{key: 'pvbs', expire_after: 20.minutes, httponly: true, max_age: 20.minutes, domain: SERVICE_DOMAIN}.tap do |configuration|
-  configuration[:secure] = Rails.env.production?
-  PrisonVisits2::Application.config.session_store :cookie_store, configuration
-end
+PrisonVisits2::Application.config.session_store :cookie_store,
+  key: 'pvbs',
+  expire_after: 20.minutes,
+  httponly: true,
+  max_age: 20.minutes,
+  domain: SERVICE_DOMAIN,
+  secure: Rails.env.production?

--- a/lib/sendgrid_helper.rb
+++ b/lib/sendgrid_helper.rb
@@ -33,7 +33,7 @@ module SendgridHelper
   end
 
   def self.smtp_settings
-    Rails.configuration.action_mailer.smtp_settings
+    Rails.configuration.action_mailer.smtp_settings || {}
   end
 
   def self.spam_reported_url(email)

--- a/spec/controllers/deferred/slots_controller_spec.rb
+++ b/spec/controllers/deferred/slots_controller_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe Deferred::SlotsController, type: :controller do
 
   before :each do
     Timecop.freeze(Time.local(2013, 12, 1, 12, 0))
-    session[:visit] = Visit.new(visit_id: SecureRandom.hex, prisoner: Prisoner.new, visitors: [Visitor.new], slots: [])
+    session[:visit] = Visit.new(
+      visit_id: SecureRandom.hex,
+      prisoner: Prisoner.new(prison_name: 'Cardiff'),
+      visitors: [Visitor.new],
+      slots: []
+    )
     cookies['cookies-enabled'] = 1
   end
 

--- a/spec/controllers/instant/slots_controller_spec.rb
+++ b/spec/controllers/instant/slots_controller_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe Instant::SlotsController, type: :controller do
 
   before :each do
     Timecop.freeze(Time.local(2013, 12, 1, 12, 0))
-    session[:visit] = Visit.new(visit_id: SecureRandom.hex, prisoner: Prisoner.new, visitors: [Visitor.new], slots: [])
+    session[:visit] = Visit.new(
+      visit_id: SecureRandom.hex,
+      prisoner: Prisoner.new(prison_name: 'Durham'),
+      visitors: [Visitor.new],
+      slots: []
+    )
     cookies['cookies-enabled'] = 1
   end
 

--- a/spec/features/unexpected_journey_spec.rb
+++ b/spec/features/unexpected_journey_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.feature 'unexpected journeys through the application' do
+  before do
+    Capybara.current_driver = :rack_test
+  end
+
   def complete_prisoner_details
     fill_in 'Prisoner first name', with: 'Arthur'
     fill_in 'Prisoner last name', with: 'Raffles'

--- a/spec/features/unexpected_journey_spec.rb
+++ b/spec/features/unexpected_journey_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.feature 'unexpected journeys through the application' do
+  def complete_prisoner_details
+    fill_in 'Prisoner first name', with: 'Arthur'
+    fill_in 'Prisoner last name', with: 'Raffles'
+    fill_in 'Day', with: '1'
+    fill_in 'Month', with: '1'
+    fill_in 'Year', with: '1980'
+    fill_in 'Prisoner number', with: 'a1234bc'
+    select 'Cardiff', from: 'Name of the prison'
+  end
+
+  def complete_visitor_details
+    fill_in 'Your first name', with: 'Harry'
+    fill_in 'Your last name', with: 'Manders'
+    fill_in 'Day', with: '1'
+    fill_in 'Month', with: '1'
+    fill_in 'Year', with: '1980'
+    fill_in 'Email address', with: 'user@digital.justice.gov.uk'
+    fill_in 'Phone number', with: '0115 496 0123'
+  end
+
+  def complete_visit_details
+    slot = first('.SlotPicker-input option[value!=""]').text
+    select slot, from: 'Option 1'
+  end
+
+  def status
+    page.driver.browser.last_response.status
+  end
+
+  def clear_session
+    # THE SHAME OF IT
+    # rack-test lets us set a cookie, or clear all of them, but deleting a
+    # single cookie is concealed beneath a few layers of indirection.
+    page.driver.browser.current_session.
+      instance_variable_get('@rack_mock_session').cookie_jar.delete 'pvbs'
+  end
+
+  def have_title(t)
+    have_selector('h1', text: t)
+  end
+
+  before do
+    visit '/prisoner'
+  end
+
+  context 'session expires' do
+    scenario 'while entering prisoner details' do
+      complete_prisoner_details
+      clear_session
+      click_button 'Continue'
+
+      expect(status).to eq(200)
+      expect(page).to have_text('Your session timed out')
+      expect(page).to have_title('Who are you visiting?')
+    end
+
+    scenario 'while entering visitor details' do
+      complete_prisoner_details
+      click_button 'Continue'
+
+      complete_visitor_details
+      clear_session
+      click_button 'Continue'
+
+      expect(status).to eq(200)
+      expect(page).to have_text('Your session timed out')
+      expect(page).to have_title('Who are you visiting?')
+    end
+
+    scenario 'while entering visit details' do
+      complete_prisoner_details
+      click_button 'Continue'
+
+      complete_visitor_details
+      click_button 'Continue'
+
+      complete_visit_details
+      clear_session
+      click_button 'Continue'
+
+      expect(status).to eq(200)
+      expect(page).to have_text('Your session timed out')
+      expect(page).to have_title('Who are you visiting?')
+    end
+
+    scenario 'on the confirmation page' do
+      complete_prisoner_details
+      click_button 'Continue'
+
+      complete_visitor_details
+      click_button 'Continue'
+
+      complete_visit_details
+      click_button 'Continue'
+
+      clear_session
+      click_button 'Send request'
+
+      expect(status).to eq(200)
+      expect(page).to have_text('Your session timed out')
+      expect(page).to have_title('Who are you visiting?')
+    end
+  end
+end

--- a/spec/features/unexpected_journey_spec.rb
+++ b/spec/features/unexpected_journey_spec.rb
@@ -122,6 +122,7 @@ RSpec.feature 'unexpected journeys through the application' do
 
         expect(status).to eq(200)
         expect(current_path).to eq(start_page)
+        expect(page).to have_text('You need to complete missing information')
         expect(page).to have_title('Who are you visiting?')
       end
 
@@ -130,6 +131,7 @@ RSpec.feature 'unexpected journeys through the application' do
 
         expect(status).to eq(200)
         expect(current_path).to eq(start_page)
+        expect(page).to have_text('You need to complete missing information')
         expect(page).to have_title('Who are you visiting?')
       end
 
@@ -138,6 +140,7 @@ RSpec.feature 'unexpected journeys through the application' do
 
         expect(status).to eq(200)
         expect(current_path).to eq(start_page)
+        expect(page).to have_text('You need to complete missing information')
         expect(page).to have_title('Who are you visiting?')
       end
     end

--- a/spec/features/unexpected_journey_spec.rb
+++ b/spec/features/unexpected_journey_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'unexpected journeys through the application' do
     fill_in 'Month', with: '1'
     fill_in 'Year', with: '1980'
     fill_in 'Prisoner number', with: 'a1234bc'
-    select 'Cardiff', from: 'Name of the prison'
+    select prison_name, from: 'Name of the prison'
   end
 
   def complete_visitor_details
@@ -46,66 +46,100 @@ RSpec.feature 'unexpected journeys through the application' do
     have_selector('h1', text: t)
   end
 
-  before do
-    visit '/prisoner'
+  def start_page
+    '/prisoner'
   end
 
-  context 'session expires' do
-    scenario 'while entering prisoner details' do
-      complete_prisoner_details
-      clear_session
-      click_button 'Continue'
+  before do
+    visit start_page
+  end
 
-      expect(status).to eq(200)
-      expect(page).to have_text('Your session timed out')
-      expect(page).to have_title('Who are you visiting?')
+  context 'deferred' do
+    let(:prison_name) { 'Cardiff' }
+
+    context 'session expires' do
+      scenario 'while entering prisoner details' do
+        complete_prisoner_details
+        clear_session
+        click_button 'Continue'
+
+        expect(status).to eq(200)
+        expect(page).to have_text('Your session timed out')
+        expect(page).to have_title('Who are you visiting?')
+      end
+
+      scenario 'while entering visitor details' do
+        complete_prisoner_details
+        click_button 'Continue'
+
+        complete_visitor_details
+        clear_session
+        click_button 'Continue'
+
+        expect(status).to eq(200)
+        expect(page).to have_text('Your session timed out')
+        expect(page).to have_title('Who are you visiting?')
+      end
+
+      scenario 'while entering visit details' do
+        complete_prisoner_details
+        click_button 'Continue'
+
+        complete_visitor_details
+        click_button 'Continue'
+
+        complete_visit_details
+        clear_session
+        click_button 'Continue'
+
+        expect(status).to eq(200)
+        expect(page).to have_text('Your session timed out')
+        expect(page).to have_title('Who are you visiting?')
+      end
+
+      scenario 'on the confirmation page' do
+        complete_prisoner_details
+        click_button 'Continue'
+
+        complete_visitor_details
+        click_button 'Continue'
+
+        complete_visit_details
+        click_button 'Continue'
+
+        clear_session
+        click_button 'Send request'
+
+        expect(status).to eq(200)
+        expect(page).to have_text('Your session timed out')
+        expect(page).to have_title('Who are you visiting?')
+      end
     end
 
-    scenario 'while entering visitor details' do
-      complete_prisoner_details
-      click_button 'Continue'
+    context 'skipping the prisoner step' do
+      scenario 'and going to visitor details' do
+        visit '/deferred/visitors'
 
-      complete_visitor_details
-      clear_session
-      click_button 'Continue'
+        expect(status).to eq(200)
+        expect(current_path).to eq(start_page)
+        expect(page).to have_title('Who are you visiting?')
+      end
 
-      expect(status).to eq(200)
-      expect(page).to have_text('Your session timed out')
-      expect(page).to have_title('Who are you visiting?')
-    end
+      scenario 'and going directly to visit details' do
+        visit '/deferred/slots'
 
-    scenario 'while entering visit details' do
-      complete_prisoner_details
-      click_button 'Continue'
+        expect(status).to eq(200)
+        expect(current_path).to eq(start_page)
+        expect(page).to have_title('Who are you visiting?')
+      end
 
-      complete_visitor_details
-      click_button 'Continue'
+      scenario 'and going directly to the confirmation page' do
+        visit '/deferred/visit'
 
-      complete_visit_details
-      clear_session
-      click_button 'Continue'
-
-      expect(status).to eq(200)
-      expect(page).to have_text('Your session timed out')
-      expect(page).to have_title('Who are you visiting?')
-    end
-
-    scenario 'on the confirmation page' do
-      complete_prisoner_details
-      click_button 'Continue'
-
-      complete_visitor_details
-      click_button 'Continue'
-
-      complete_visit_details
-      click_button 'Continue'
-
-      clear_session
-      click_button 'Send request'
-
-      expect(status).to eq(200)
-      expect(page).to have_text('Your session timed out')
-      expect(page).to have_title('Who are you visiting?')
+        expect(status).to eq(200)
+        expect(current_path).to eq(start_page)
+        expect(page).to have_title('Who are you visiting?')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds specs and fixes for journeys that are outside the expected path, i.e. where the session expires, or where the back button is used.

This seems to rule out session expiry as a cause of 500 errors, but does identify a large class of problems that can happen when a visitor jumps straight to a later page without the expected information in their session.

After the first step, the session must contain a visit, which has a prisoner, who has a prison name. Without this, the prison data cannot be retrieved and an exception results.

Now, if the session doesn't contain this information, we'll redirect the visitor back to the first step and get them to start again. This won't solve every possible 500 error, but it should make a difference.