### PR TITLE
Let visitors override spam/bounced email rejection

### DIFF
--- a/.default_rubocop.yml
+++ b/.default_rubocop.yml
@@ -66,6 +66,11 @@ Style/StringLiterals:
   Exclude:
     - 'spec/**/*'
 
+# Allow us to define simple predicate methods like foo? that look at the value
+# of @foo. See https://github.com/bbatsov/rubocop/issues/2140
+Style/TrivialAccessors:
+  AllowPredicates: true
+
 # Prefer sensible naming to comments everywhere.
 Documentation:
   Description: Document classes and non-namespace modules.

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -41,7 +41,7 @@ class VisitorMailer < ActionMailer::Base
     @visit = visit
     @token = token
 
-    perform_sendgrid_resets
+    SpamAndBounceResets.new(@visit.visitors.first).perform_resets
 
     mail(from: sender,
          reply_to: prison_mailbox_email,
@@ -69,21 +69,5 @@ class VisitorMailer < ActionMailer::Base
 
   def confirmation_date
     Date.parse(@slot.date).strftime('%e %B %Y').gsub(/^ /,'')
-  end
-
-  def first_visitor
-    @visit.visitors.first
-  end
-
-  delegate :email, :reset_bounce?, :reset_spam_report?,
-    :override_email_checks?, to: :first_visitor
-
-  delegate :remove_from_bounce_list, :remove_from_spam_list,
-    to: :SendgridApi
-
-  def perform_sendgrid_resets
-    return unless override_email_checks?
-    remove_from_bounce_list(email) if reset_bounce?
-    remove_from_spam_list(email) if reset_spam_report?
   end
 end

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -21,21 +21,30 @@ class VisitorMailer < ActionMailer::Base
     @confirmation = confirmation
     @token = token
 
-    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Visit confirmed: your visit for #{Date.parse(@slot.date).strftime('%e %B %Y').gsub(/^ /,'')} has been confirmed")
+    mail(from: sender,
+         reply_to: prison_mailbox_email,
+         to: recipient,
+         subject: "Visit confirmed: your visit for #{confirmation_date} has been confirmed")
   end
 
   def booking_rejection_email(visit, confirmation)
     @visit = visit
     @confirmation = confirmation
 
-    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Visit cannot take place: your visit for #{first_date.strftime('%e %B %Y').gsub(/^ /,'')} could not be booked")
+    mail(from: sender,
+         reply_to: prison_mailbox_email,
+         to: recipient,
+         subject: "Visit cannot take place: your visit for #{rejection_date} could not be booked")
   end
 
   def booking_receipt_email(visit, token)
     @visit = visit
     @token = token
 
-    mail(from: sender, reply_to: prison_mailbox_email, to: recipient, subject: "Not booked yet: we've received your visit request for #{first_date.strftime('%e %B %Y').gsub(/^ /,'')}")
+    mail(from: sender,
+         reply_to: prison_mailbox_email,
+         to: recipient,
+         subject: "Not booked yet: we've received your visit request for #{receipt_date}")
   end
 
   def sender
@@ -48,5 +57,15 @@ class VisitorMailer < ActionMailer::Base
 
   def first_date
     Date.parse(@visit.slots.first.date)
+  end
+
+  def receipt_date
+    first_date.strftime('%e %B %Y').gsub(/^ /,'')
+  end
+
+  alias_method :rejection_date, :receipt_date
+
+  def confirmation_date
+    Date.parse(@slot.date).strftime('%e %B %Y').gsub(/^ /,'')
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -8,5 +8,12 @@ class Feedback
   attribute :prison, String
 
   validates_presence_of :text
-  validates :email, email: true, if: ->(f) { f.email.present? }
+  validate :validate_email, if: ->(f) { f.email.present? }
+
+  private
+
+  def validate_email
+    validator = EmailValidator.new(email)
+    errors.add :email, validator.message unless validator.valid?
+  end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -6,6 +6,7 @@ class Visitor
 
   attribute :email, String
   attribute :override_email_checks, Boolean
+  attribute :email_override, String
   attribute :index, Integer
   attribute :number_of_adults, Integer
   attribute :number_of_children, Integer
@@ -33,18 +34,14 @@ class Visitor
     @override_email_checks
   end
 
-  delegate :reset_bounce?, :reset_spam_report?, to: :email_validator
-
   private
 
   def validate_email
-    unless email_validator.valid?
-      errors.add :email, email_validator.message
-      @email_overrideable = email_validator.overrideable?
+    validator = EmailValidator.new(email, override_email_checks)
+    unless validator.valid?
+      errors.add :email, validator.message
+      @email_overrideable = validator.overrideable?
+      @email_override = validator.error
     end
-  end
-
-  def email_validator
-    @email_validator ||= EmailValidator.new(email, override_email_checks)
   end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -5,6 +5,7 @@ class Visitor
   USER_MIN_AGE = 18
 
   attribute :email, String
+  attribute :override_email_checks, Boolean
   attribute :index, Integer
   attribute :number_of_adults, Integer
   attribute :number_of_children, Integer
@@ -24,10 +25,17 @@ class Visitor
     index > 0
   end
 
+  def email_overrideable?
+    @email_overrideable
+  end
+
   private
 
   def validate_email
-    validator = EmailValidator.new(email)
-    errors.add :email, validator.message unless validator.valid?
+    validator = EmailValidator.new(email, override_email_checks)
+    unless validator.valid?
+      errors.add :email, validator.message
+      @email_overrideable = true
+    end
   end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -35,7 +35,7 @@ class Visitor
     validator = EmailValidator.new(email, override_email_checks)
     unless validator.valid?
       errors.add :email, validator.message
-      @email_overrideable = true
+      @email_overrideable = validator.overrideable?
     end
   end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -11,13 +11,10 @@ class Visitor
   attribute :phone, String
 
   validates :email, absence: true, if: :additional?
+  validates :email, presence: true, if: :primary?
   validate :validate_email, if: :primary?
   validates :phone, absence: true, if: :additional?
   validates :phone, presence: true, length: { minimum: 9 }, if: :primary?
-
-  def validate_email
-    EmailValidator.new.validate(self)
-  end
 
   def primary?
     index == 0
@@ -25,5 +22,12 @@ class Visitor
 
   def additional?
     index > 0
+  end
+
+  private
+
+  def validate_email
+    validator = EmailValidator.new(email)
+    errors.add :email, validator.message unless validator.valid?
   end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -29,13 +29,22 @@ class Visitor
     @email_overrideable
   end
 
+  def override_email_checks?
+    @override_email_checks
+  end
+
+  delegate :reset_bounce?, :reset_spam_report?, to: :email_validator
+
   private
 
   def validate_email
-    validator = EmailValidator.new(email, override_email_checks)
-    unless validator.valid?
-      errors.add :email, validator.message
-      @email_overrideable = validator.overrideable?
+    unless email_validator.valid?
+      errors.add :email, email_validator.message
+      @email_overrideable = email_validator.overrideable?
     end
+  end
+
+  def email_validator
+    @email_validator ||= EmailValidator.new(email, override_email_checks)
   end
 end

--- a/app/services/spam_and_bounce_resets.rb
+++ b/app/services/spam_and_bounce_resets.rb
@@ -1,0 +1,21 @@
+class SpamAndBounceResets
+  def initialize(visitor)
+    @visitor = visitor
+  end
+
+  delegate :email, :override_email_checks?, :email_override, to: :@visitor
+
+  delegate :remove_from_bounce_list, :remove_from_spam_list, to: :SendgridApi
+
+  def perform_resets
+    return unless override_email_checks?
+    remove_from_bounce_list(email) if reset.bounced?
+    remove_from_spam_list(email) if reset.spam_reported?
+  end
+
+  private
+
+  def reset
+    email_override.inquiry
+  end
+end

--- a/app/views/shared/visitors_details/_visitor_fields.html.haml
+++ b/app/views/shared/visitors_details/_visitor_fields.html.haml
@@ -50,6 +50,7 @@
         - if f.object.email_overrideable?
           %label.validation-message
             = check_box_tag 'visit[visitor][][override_email_checks]', 1, false
+            = hidden_field_tag 'visit[visitor][][email_override]', f.object.email_override
             Tick this box to confirm you’d like us to try sending messages to you again.
       = email_field_tag 'visit[visitor][][email]', f.object.email, :'aria-describedby' => "emailHint"
 

--- a/app/views/shared/visitors_details/_visitor_fields.html.haml
+++ b/app/views/shared/visitors_details/_visitor_fields.html.haml
@@ -45,8 +45,12 @@
     =group_container(f, :email) do
       %label{for: 'visit_visitor__email'}
         Email address
+        %p.form-hint#emailHint You'll receive confirmation by email.
         =field_error(f, :email)
-      %p.form-hint#emailHint You'll receive confirmation by email.
+        - if f.object.email_overrideable?
+          %label.validation-message
+            = check_box_tag 'visit[visitor][][override_email_checks]', 1, false
+            Tick this box to confirm you’d like us to try sending messages to you again.
       = email_field_tag 'visit[visitor][][email]', f.object.email, :'aria-describedby' => "emailHint"
 
     - if @collect_phone_number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,8 +28,7 @@ en:
       malformed: "is not a valid address"
       no_mx_record: "does not appear to be valid"
       spam_reported: >
-        We’ve tried to send messages to this email address in the past and
-        believe they were marked as spam.
+        needs to be checked as past messages were marked as spam.
+        Check your spam folder too
       bounced: >
-        We’ve tried to send messages to this email address in the past and
-        the address was found to be incorrect.
+        needs to be checked as messages have been returned in the past

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,10 +22,10 @@ en:
         four_digit_year: 'year must be four digits'
   email_validator:
     errors:
-      invalid_address: "is not a valid address"
+      unparseable: "is not a valid address"
       domain_dot: "is not a valid address because it ends with a dot or starts with a dot"
       bad_domain: "does not appear to be valid"
-      malformed_address: "is not a valid address"
+      malformed: "is not a valid address"
       no_mx_record: "does not appear to be valid"
       spam_reported: "cannot receive messages from this system"
       bounced: "cannot receive messages from this system"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,5 +27,9 @@ en:
       bad_domain: "does not appear to be valid"
       malformed: "is not a valid address"
       no_mx_record: "does not appear to be valid"
-      spam_reported: "cannot receive messages from this system"
-      bounced: "cannot receive messages from this system"
+      spam_reported: >
+        We’ve tried to send messages to this email address in the past and
+        believe they were marked as spam.
+      bounced: >
+        We’ve tried to send messages to this email address in the past and
+        the address was found to be incorrect.

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -55,7 +55,7 @@ class EmailValidator
       return :spam_reported if spam_reported?(parsed.address)
       return :bounced if bounced?(parsed.address)
     end
-    return nil
+    nil
   end
 
   def override_sendgrid?

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -45,6 +45,7 @@ class EmailValidator
   attr_reader :original_address, :parsed
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def compute_error
     return :unparseable unless parsed
     return :domain_dot if domain_dot_error?

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -29,6 +29,16 @@ class EmailValidator
     [:spam_reported, :bounced].include?(error)
   end
 
+  def reset_bounce?
+    return false unless parsed
+    override_sendgrid? && bounced?(parsed.address)
+  end
+
+  def reset_spam_report?
+    return false unless parsed
+    override_sendgrid? && spam_reported?(parsed.address)
+  end
+
   private
 
   attr_reader :original_address
@@ -40,11 +50,15 @@ class EmailValidator
     return :bad_domain if bad_domain?
     return :malformed unless well_formed_address?
     return :no_mx_record unless has_mx_records?
-    unless @override_sendgrid
+    unless override_sendgrid?
       return :spam_reported if spam_reported?(parsed.address)
       return :bounced if bounced?(parsed.address)
     end
     return nil
+  end
+
+  def override_sendgrid?
+    @override_sendgrid
   end
 
   def domain

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -6,6 +6,7 @@ class EmailValidator
 
   def initialize(original_address, override_sendgrid = false)
     @original_address = original_address
+    @parsed = parse_address(original_address)
     @override_sendgrid = override_sendgrid
   end
 
@@ -41,7 +42,7 @@ class EmailValidator
 
   private
 
-  attr_reader :original_address
+  attr_reader :original_address, :parsed
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def compute_error
@@ -62,15 +63,11 @@ class EmailValidator
   end
 
   def domain
-    parsed && parsed.domain
+    parsed.domain
   end
 
-  def parsed
-    @parsed ||= parse_address
-  end
-
-  def parse_address
-    Mail::Address.new(original_address)
+  def parse_address(addr)
+    Mail::Address.new(addr)
   rescue Mail::Field::ParseError
     nil
   end

--- a/spec/features/datepicker_spec.rb
+++ b/spec/features/datepicker_spec.rb
@@ -2,8 +2,7 @@ require 'poltergeist_helper'
 
 RSpec.feature "visitor selects a date" do
   include ActiveJobHelper
-
-  include_examples "feature helper"
+  include FeaturesHelper
 
   before :all do
     Timecop.travel(Time.now.next_week(:tuesday).at_noon)

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "overriding Sendgrid" do
   let(:irrelevant_response) { {'message' => 'success'} }
 
   scenario 'overriding spam report' do
-    allow(SendgridApi).to receive(:spam_reported?).and_return(true)
+    allow(SendgridApi).to receive(:spam_reported?).once.and_return(true)
 
     visit '/prisoner-details'
     enter_prisoner_information
@@ -41,7 +41,7 @@ RSpec.feature "overriding Sendgrid" do
   end
 
   scenario 'overriding bounce' do
-    allow(SendgridApi).to receive(:bounced?).and_return(true)
+    allow(SendgridApi).to receive(:bounced?).once.and_return(true)
 
     visit '/prisoner-details'
     enter_prisoner_information

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -29,4 +29,26 @@ RSpec.feature "overriding Sendgrid" do
 
     expect(page).to have_content('Your request is being processed')
   end
+
+  scenario 'overriding bounce' do
+    allow(SendgridHelper).to receive(:bounced?).and_return(true)
+
+    visit '/prisoner-details'
+    enter_prisoner_information
+    enter_visitor_information
+    click_button 'Continue'
+
+    expect(page).to have_text('returned in the past')
+    check 'Tick this box to confirm you’d like us to try sending messages to you again'
+    click_button 'Continue'
+
+    expect(page).to have_content('When do you want to visit?')
+    select_a_slot
+    click_button 'Continue'
+
+    expect(page).to have_content('Check your request')
+    click_button 'Send request'
+
+    expect(page).to have_content('Your request is being processed')
+  end
 end

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "overriding Sendgrid" do
   end
 
   scenario 'overriding spam report' do
-    allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
+    allow(SendgridApi).to receive(:spam_reported?).and_return(true)
 
     visit '/prisoner-details'
     enter_prisoner_information
@@ -31,7 +31,7 @@ RSpec.feature "overriding Sendgrid" do
   end
 
   scenario 'overriding bounce' do
-    allow(SendgridHelper).to receive(:bounced?).and_return(true)
+    allow(SendgridApi).to receive(:bounced?).and_return(true)
 
     visit '/prisoner-details'
     enter_prisoner_information

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -8,6 +8,9 @@ RSpec.feature "overriding Sendgrid" do
     ActionMailer::Base.deliveries.clear
   end
 
+  let(:expected_email_address) { 'test@maildrop.dsd.io' }
+  let(:irrelevant_response) { {'message' => 'success'} }
+
   scenario 'overriding spam report' do
     allow(SendgridApi).to receive(:spam_reported?).and_return(true)
 
@@ -25,6 +28,13 @@ RSpec.feature "overriding Sendgrid" do
     click_button 'Continue'
 
     expect(page).to have_content('Check your request')
+
+    expect(SendgridApi).to receive(:remove_from_spam_list).
+      with(expected_email_address).
+      and_return(irrelevant_response)
+
+    expect(SendgridApi).to_not receive(:remove_from_bounce_list)
+
     click_button 'Send request'
 
     expect(page).to have_content('Your request is being processed')
@@ -47,6 +57,13 @@ RSpec.feature "overriding Sendgrid" do
     click_button 'Continue'
 
     expect(page).to have_content('Check your request')
+
+    expect(SendgridApi).to receive(:remove_from_bounce_list).
+      with(expected_email_address).
+      and_return(irrelevant_response)
+
+    expect(SendgridApi).to_not receive(:remove_from_spam_list)
+
     click_button 'Send request'
 
     expect(page).to have_content('Your request is being processed')

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -1,0 +1,32 @@
+require 'poltergeist_helper'
+
+RSpec.feature "overriding Sendgrid" do
+  include ActiveJobHelper
+  include FeaturesHelper
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  scenario 'overriding spam report' do
+    allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
+
+    visit '/prisoner-details'
+    enter_prisoner_information
+    enter_visitor_information
+    click_button 'Continue'
+
+    expect(page).to have_text('marked as spam')
+    check 'Tick this box to confirm you’d like us to try sending messages to you again'
+    click_button 'Continue'
+
+    expect(page).to have_content('When do you want to visit?')
+    select_a_slot
+    click_button 'Continue'
+
+    expect(page).to have_content('Check your request')
+    click_button 'Send request'
+
+    expect(page).to have_content('Your request is being processed')
+  end
+end

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -68,4 +68,24 @@ RSpec.feature "overriding Sendgrid" do
 
     expect(page).to have_content('Your request is being processed')
   end
+
+  scenario 'when no overrides are present' do
+    visit '/prisoner-details'
+    enter_prisoner_information
+    enter_visitor_information
+    click_button 'Continue'
+
+    expect(page).to have_content('When do you want to visit?')
+    select_a_slot
+    click_button 'Continue'
+
+    expect(page).to have_content('Check your request')
+
+    expect(SendgridApi).to_not receive(:remove_from_bounce_list)
+    expect(SendgridApi).to_not receive(:remove_from_spam_list)
+
+    click_button 'Send request'
+
+    expect(page).to have_content('Your request is being processed')
+  end
 end

--- a/spec/features/prison_information_page_spec.rb
+++ b/spec/features/prison_information_page_spec.rb
@@ -1,7 +1,7 @@
 require 'poltergeist_helper'
 
 RSpec.feature 'visitor entering prisoner information' do
-  include_examples 'feature helper'
+  include FeaturesHelper
 
   before(:each) { visit edit_prisoner_details_path }
 

--- a/spec/features/visitor_information_page_spec.rb
+++ b/spec/features/visitor_information_page_spec.rb
@@ -71,4 +71,19 @@ RSpec.feature "visitor enters visitor information" do
     end
 
   end
+
+  scenario 'overriding spam report' do
+    allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
+
+    visit '/prisoner-details'
+    enter_prisoner_information
+    enter_visitor_information
+    click_button 'Continue'
+
+    expect(page).to have_text('marked as spam')
+    check 'Tick this box to confirm you’d like us to try sending messages to you again'
+    click_button 'Continue'
+
+    expect(page).to have_content('When do you want to visit?')
+  end
 end

--- a/spec/features/visitor_information_page_spec.rb
+++ b/spec/features/visitor_information_page_spec.rb
@@ -71,19 +71,4 @@ RSpec.feature "visitor enters visitor information" do
     end
 
   end
-
-  scenario 'overriding spam report' do
-    allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
-
-    visit '/prisoner-details'
-    enter_prisoner_information
-    enter_visitor_information
-    click_button 'Continue'
-
-    expect(page).to have_text('marked as spam')
-    check 'Tick this box to confirm you’d like us to try sending messages to you again'
-    click_button 'Continue'
-
-    expect(page).to have_content('When do you want to visit?')
-  end
 end

--- a/spec/features/visitor_information_page_spec.rb
+++ b/spec/features/visitor_information_page_spec.rb
@@ -1,7 +1,7 @@
 require 'poltergeist_helper'
 
 RSpec.feature "visitor enters visitor information" do
-  include_examples "feature helper"
+  include FeaturesHelper
 
   before :each do
     visit edit_prisoner_details_path

--- a/spec/lib/email_validator_spec.rb
+++ b/spec/lib/email_validator_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe EmailValidator do
     end
 
     it 'checks Sendgrid only once' do
-      expect(SendgridHelper).to receive(:spam_reported?).once.and_return(false)
-      expect(SendgridHelper).to receive(:bounced?).once.and_return(false)
+      expect(SendgridApi).to receive(:spam_reported?).once.and_return(false)
+      expect(SendgridApi).to receive(:bounced?).once.and_return(false)
 
       2.times do
         subject.valid?
@@ -110,7 +110,7 @@ RSpec.describe EmailValidator do
 
     context 'when spam is reported' do
       before do
-        allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
+        allow(SendgridApi).to receive(:spam_reported?).and_return(true)
       end
 
       it { is_expected.to be_overrideable }
@@ -129,7 +129,7 @@ RSpec.describe EmailValidator do
 
     context 'when bounce is reported' do
       before do
-        allow(SendgridHelper).to receive(:bounced?).and_return(true)
+        allow(SendgridApi).to receive(:bounced?).and_return(true)
       end
 
       it { is_expected.to be_overrideable }

--- a/spec/lib/email_validator_spec.rb
+++ b/spec/lib/email_validator_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe EmailValidator do
       let(:address) { '' }
       it_behaves_like 'an invalid address', :malformed
       it { is_expected.not_to be_overrideable }
+      it { is_expected.not_to be_reset_spam_report }
+      it { is_expected.not_to be_reset_bounce }
     end
 
     context 'with domain only' do
@@ -111,12 +113,17 @@ RSpec.describe EmailValidator do
         allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
       end
 
-      it_behaves_like 'an invalid address', :spam_reported
       it { is_expected.to be_overrideable }
+
+      context 'and override is not set' do
+        it_behaves_like 'an invalid address', :spam_reported
+        it { is_expected.not_to be_reset_spam_report }
+      end
 
       context 'but override is set' do
         let(:override) { true }
         it_behaves_like 'a valid address'
+        it { is_expected.to be_reset_spam_report }
       end
     end
 
@@ -125,12 +132,17 @@ RSpec.describe EmailValidator do
         allow(SendgridHelper).to receive(:bounced?).and_return(true)
       end
 
-      it_behaves_like 'an invalid address', :bounced
       it { is_expected.to be_overrideable }
+
+      context 'and override is not set' do
+        it_behaves_like 'an invalid address', :bounced
+        it { is_expected.not_to be_reset_bounce }
+      end
 
       context 'but override is set' do
         let(:override) { true }
         it_behaves_like 'a valid address'
+        it { is_expected.to be_reset_bounce }
       end
     end
   end

--- a/spec/poltergeist_helper.rb
+++ b/spec/poltergeist_helper.rb
@@ -5,3 +5,4 @@ require 'capybara/poltergeist'
 Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
 Capybara.default_wait_time = 3
+Capybara.asset_host = "http://localhost:3000"

--- a/spec/services/sendgrid_api_spec.rb
+++ b/spec/services/sendgrid_api_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe SendgridApi do
         let(:body) { '{"message": "Email does not exist"}' }
 
         specify do
-          expect(subject.remove_from_bounce_list('test@example.com')).to be false
+          expect(subject.remove_from_bounce_list('test@example.com')).to be_falsey
         end
       end
 
@@ -268,7 +268,7 @@ RSpec.describe SendgridApi do
         let(:body) { '{"message": "Email does not exist"}' }
 
         specify do
-          expect(subject.remove_from_spam_list('test@example.com')).to be false
+          expect(subject.remove_from_spam_list('test@example.com')).to be_falsey
         end
       end
 
@@ -314,7 +314,7 @@ RSpec.describe SendgridApi do
 
     describe '.remove_from_bounce_list' do
       specify do
-        expect(subject.remove_from_bounce_list('test@example.com')).to be false
+        expect(subject.remove_from_bounce_list('test@example.com')).to be_falsey
       end
 
       it 'does not talk to sendgrid' do
@@ -325,7 +325,7 @@ RSpec.describe SendgridApi do
 
     describe '.remove_from_spam_list' do
       specify do
-        expect(subject.remove_from_spam_list('test@example.com')).to be false
+        expect(subject.remove_from_spam_list('test@example.com')).to be_falsey
       end
 
       it 'does not talk to sendgrid' do

--- a/spec/services/sendgrid_api_spec.rb
+++ b/spec/services/sendgrid_api_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SendgridApi do
       Rails.configuration.action_mailer.smtp_settings = smtp_settings
     end
 
-    context 'spam reports' do
+    describe '.spam_reported?' do
       let(:body) { '[]' }
 
       before do
@@ -82,7 +82,7 @@ RSpec.describe SendgridApi do
       end
     end
 
-    context 'bounced' do
+    describe '.bounced?' do
       let(:body) { '[]' }
 
       before do
@@ -290,7 +290,7 @@ RSpec.describe SendgridApi do
       Rails.configuration.action_mailer.smtp_settings = smtp_settings
     end
 
-    context 'bounced?' do
+    describe '.bounced?' do
       it 'never says that the email has bounced' do
         expect(subject.bounced?('test@example.com')).to be_falsey
       end
@@ -301,7 +301,7 @@ RSpec.describe SendgridApi do
       end
     end
 
-    context 'spam_reported?' do
+    describe '.spam_reported?' do
       it 'never says that the email address has been reported for spam' do
         expect(subject.spam_reported?('test@example.com')).to be_falsey
       end

--- a/spec/services/sendgrid_api_spec.rb
+++ b/spec/services/sendgrid_api_spec.rb
@@ -150,6 +150,136 @@ RSpec.describe SendgridApi do
         end
       end
     end
+
+    describe '.remove_from_bounce_list' do
+      let(:body) { nil }
+
+      before do
+        stub_request(:post, 'https://api.sendgrid.com/api/bounces.delete.json').
+          with(query: hash_including(
+            'api_key'   => 'test_smtp_password',
+            'api_user'  => 'test_smtp_username',
+            'email'     => 'test@example.com')).
+           to_return(status: 200, body: body, headers: {})
+      end
+
+      context 'error handling' do
+        context 'when the API raises an exception' do
+          before do
+            stub_request(:post, 'https://api.sendgrid.com/api/bounces.delete.json').
+              with(query: hash_including(
+                'api_key'   => 'test_smtp_password',
+                'api_user'  => 'test_smtp_username',
+                'email'     => 'test@example.com')).
+               to_raise(StandardError)
+          end
+
+          specify do
+            expect { subject.remove_from_bounce_list('test@example.com')}.
+              to raise_error(StandardError)
+          end
+        end
+
+        context 'when the API reports an error' do
+          let(:body) { '{"error":"LOL"}' }
+
+          specify do
+            expect { subject.remove_from_bounce_list('test@example.com') }.
+              to raise_error(SendgridToolkit::APIError)
+          end
+        end
+
+        context 'when the API returns non-JSON' do
+          let(:body) { 'Oopsy daisy' }
+
+          specify do
+            expect { subject.remove_from_bounce_list('test@example.com') }.
+              to raise_error(JSON::ParserError)
+          end
+        end
+      end
+
+      context 'when there is no bounce' do
+        let(:body) { '{"message": "Email does not exist"}' }
+
+        specify do
+          expect(subject.remove_from_bounce_list('test@example.com')).to be false
+        end
+      end
+
+      context 'when there is a bounce' do
+        let(:body) { '{"message": "success"}' }
+
+        it 'removes it' do
+          expect(subject.remove_from_bounce_list('test@example.com')).to be_truthy
+        end
+      end
+    end
+
+    describe '.remove_from_spam_list' do
+      let(:body) { nil }
+
+      before do
+        stub_request(:post, 'https://api.sendgrid.com/api/spamreports.delete.json').
+          with(query: hash_including(
+            'api_key'   => 'test_smtp_password',
+            'api_user'  => 'test_smtp_username',
+            'email'     => 'test@example.com')).
+           to_return(status: 200, body: body, headers: {})
+      end
+
+      context 'error handling' do
+        context 'when the API raises an exception' do
+          before do
+            stub_request(:post, 'https://api.sendgrid.com/api/spamreports.delete.json').
+              with(query: hash_including(
+                'api_key'   => 'test_smtp_password',
+                'api_user'  => 'test_smtp_username',
+                'email'     => 'test@example.com')).
+               to_raise(StandardError)
+          end
+
+          specify do
+            expect { subject.remove_from_spam_list('test@example.com')}.
+              to raise_error(StandardError)
+          end
+        end
+
+        context 'when the API reports an error' do
+          let(:body) { '{"error":"LOL"}' }
+
+          specify do
+            expect { subject.remove_from_spam_list('test@example.com') }.
+              to raise_error(SendgridToolkit::APIError)
+          end
+        end
+
+        context 'when the API returns non-JSON' do
+          let(:body) { 'Oopsy daisy' }
+
+          specify do
+            expect { subject.remove_from_spam_list('test@example.com') }.
+              to raise_error(JSON::ParserError)
+          end
+        end
+      end
+
+      context 'when there is no bounce' do
+        let(:body) { '{"message": "Email does not exist"}' }
+
+        specify do
+          expect(subject.remove_from_spam_list('test@example.com')).to be false
+        end
+      end
+
+      context 'when there is a bounce' do
+        let(:body) { '{"message": "success"}' }
+
+        it 'removes it' do
+          expect(subject.remove_from_spam_list('test@example.com')).to be_truthy
+        end
+      end
+    end
   end
 
   context 'without sendgrid configured' do
@@ -179,6 +309,28 @@ RSpec.describe SendgridApi do
       it 'does not talk to sendgrid' do
         expect(HTTParty).to receive(:post).never
         subject.spam_reported?('test@example.com')
+      end
+    end
+
+    describe '.remove_from_bounce_list' do
+      specify do
+        expect(subject.remove_from_bounce_list('test@example.com')).to be false
+      end
+
+      it 'does not talk to sendgrid' do
+        expect(HTTParty).to receive(:post).never
+        subject.remove_from_bounce_list('test@example.com')
+      end
+    end
+
+    describe '.remove_from_spam_list' do
+      specify do
+        expect(subject.remove_from_spam_list('test@example.com')).to be false
+      end
+
+      it 'does not talk to sendgrid' do
+        expect(HTTParty).to receive(:post).never
+        subject.remove_from_spam_list('test@example.com')
       end
     end
   end

--- a/spec/support/features_helper.rb
+++ b/spec/support/features_helper.rb
@@ -50,7 +50,3 @@ module FeaturesHelper
     find(:css, ".ui-autocomplete-input").set(prison_name)
   end
 end
-
-RSpec.shared_examples "feature helper" do
-  include FeaturesHelper
-end

--- a/spec/support/visitor_support.rb
+++ b/spec/support/visitor_support.rb
@@ -78,7 +78,7 @@ RSpec.shared_examples 'a visitor' do
 
         context 'when it was marked as spam' do
           before do
-            allow(SendgridHelper).to receive(:spam_reported?).and_return(true)
+            allow(SendgridApi).to receive(:spam_reported?).and_return(true)
             subject.email = 'user@test.example.com'
             subject.validate
           end
@@ -92,7 +92,7 @@ RSpec.shared_examples 'a visitor' do
 
         context 'when it bounced' do
           before do
-            allow(SendgridHelper).to receive(:bounced?).and_return(true)
+            allow(SendgridApi).to receive(:bounced?).and_return(true)
             subject.email = 'user@test.example.com'
             subject.validate
           end


### PR DESCRIPTION
This improves the reporting of email errors when an address has been reported by Sendgrid as having bounced or been marked as spam.

It adds a checkbox to the visitor form to allow the visitor to force acceptance of an email address that failed the Sendgrid checks. The checkbox is only displayed if validation fails for one of these two reasons. If selected, we permit the email address, and tell Sendgrid to remove the spam or bounced categorisation before sending the email.