### PR TITLE
Decouple Rochester slots from visit_helper_spec

### DIFF
--- a/spec/helpers/visit_helper_spec.rb
+++ b/spec/helpers/visit_helper_spec.rb
@@ -22,13 +22,28 @@ RSpec.describe VisitHelper, type: :helper do
     end
 
     it "provides a hash of slots by day" do
+      allow(Rails.configuration.prison_data['Rochester']).
+        to receive(:[]).with('slots') { {
+            mon: ['1400-1600'],
+            tue: ['1400-1600'],
+            wed: ['1400-1600'],
+            thu: ['1400-1600'],
+            sat:[
+              '0930-1130',
+              '1400-1600',
+            ],
+            sun: ['1400-1600'],
+        } }
       expect(helper.visiting_slots).to eq({
           :mon => [["1400", "1600"]],
-          :sat => [["0930", "1130"], ["1400", "1600"]],
-          :sun => [["1400", "1600"]],
-          :thu => [["1400", "1600"]],
           :tue => [["1400", "1600"]],
-          :wed => [["1400", "1600"]]
+          :wed => [["1400", "1600"]],
+          :thu => [["1400", "1600"]],
+          :sat => [
+            ["0930", "1130"],
+            ["1400", "1600"],
+          ],
+          :sun => [["1400", "1600"]],
         })
     end
 


### PR DESCRIPTION
We don't want to have to update our tests every time Rochester's visit slots change, so mock them.

Also reorder the expected slots so they match how weeks actually work.

This will fix the issues with #275.