### PR TITLE
Add sidekiq web admin UI rackup script and required gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'statsd-ruby', require: 'statsd'
 gem 'curb'
 gem 'string_scrubber', '>= 0.2.0'
 gem 'virtus'
+gem 'sinatra'
 
 group :test, :development do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.4)
@@ -256,6 +258,10 @@ GEM
     simplecov-html (0.7.1)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
     sprockets (3.3.3)
       rack (~> 1.0)
@@ -336,6 +342,7 @@ DEPENDENCIES
   sidekiq
   simplecov (~> 0.7.1)
   simplecov-rcov
+  sinatra
   statsd-ruby
   string_scrubber (>= 0.2.0)
   timecop
@@ -343,6 +350,3 @@ DEPENDENCIES
   unicorn
   virtus
   zendesk_api
-
-BUNDLED WITH
-   1.10.6

--- a/sidekiq-admin.ru
+++ b/sidekiq-admin.ru
@@ -1,0 +1,9 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = { :size => 1 }
+end
+
+require 'sidekiq/web'
+use Rack::Session::Cookie, :secret => ENV.fetch('SESSION_SECRET_KEY')
+run Sidekiq::Web

--- a/sidekiq-admin.ru
+++ b/sidekiq-admin.ru
@@ -6,4 +6,4 @@ end
 
 require 'sidekiq/web'
 use Rack::Session::Cookie, :secret => ENV.fetch('SESSION_SECRET_KEY')
-run Sidekiq::Web
+run Rack::URLMap.new('/sidekiq' => Sidekiq::Web)


### PR DESCRIPTION
Sidekiq has a nice admin interface that gives us queue status, and can review errors etc.

Rather than using basic auth we are going to put this behind an OAuth2 gateway (run separately) and configured in the load-balancer to live under /sidekiq.

Although sidekiq is sinatra and could be mounted in the PVB app putting just one path behind OAuth would involve installing omniauth and we felt this was a smaller and safer change to make it happen this way. (It also means that there's less scope that a mistake in the config/routes.rb could open it up to theworld, but that was not the driving factor behind doing it this way.)

This was originally #280, but is now due for merging to master.