### PR TITLE
Use a third-party Sendgrid API library

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,7 +30,6 @@ Lint/AssignmentInCondition:
     - 'lib/google_analytics_adapter.rb'
     - 'lib/leaderboard_report.rb'
     - 'lib/metrics_logger.rb'
-    - 'lib/sendgrid_helper.rb'
     - 'lib/tasks/browserstack.rake'
     - 'lib/tasks/maintenance.rake'
     - 'lib/visitors_manipulator.rb'
@@ -102,7 +101,6 @@ Lint/UnusedMethodArgument:
 Lint/UselessAssignment:
   Exclude:
     - 'config/initializers/numeric.rb'
-    - 'lib/sendgrid_helper.rb'
     - 'spec/features/datepicker_spec.rb'
 
 # Offense count: 1
@@ -206,7 +204,6 @@ RSpec/DescribedClass:
     - 'spec/lib/age_validator_spec.rb'
     - 'spec/lib/email_validator_spec.rb'
     - 'spec/lib/name_validator.rb'
-    - 'spec/lib/sendgrid_helper_spec.rb'
     - 'spec/lib/zmarshal_spec.rb'
     - 'spec/mailers/feedback_mailer_spec.rb'
     - 'spec/mailers/prison_mailer_spec.rb'
@@ -344,15 +341,8 @@ Style/BracesAroundHashParameters:
     - 'spec/controllers/prisoner_details_controller_spec.rb'
     - 'spec/helpers/application_helper_spec.rb'
     - 'spec/helpers/visit_helper_spec.rb'
-    - 'spec/lib/sendgrid_helper_spec.rb'
     - 'spec/mailers/prison_mailer_spec.rb'
     - 'spec/mailers/visitor_mailer_spec.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/ClosingParenthesisIndentation:
-  Exclude:
-    - 'spec/lib/sendgrid_helper_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -393,7 +383,6 @@ Style/EmptyLinesAroundBlockBody:
     - 'spec/controllers/deferred/visitors_details_controller_spec.rb'
     - 'spec/features/visitor_information_page_spec.rb'
     - 'spec/helpers/visit_helper_spec.rb'
-    - 'spec/lib/sendgrid_helper_spec.rb'
     - 'spec/models/confirmation_spec.rb'
 
 # Offense count: 5
@@ -599,7 +588,6 @@ Style/SpaceAfterColon:
 Style/SpaceAfterComma:
   Exclude:
     - 'app/mailers/visitor_mailer.rb'
-    - 'spec/lib/sendgrid_helper_spec.rb'
 
 # Offense count: 20
 # Cop supports --auto-correct.
@@ -691,7 +679,6 @@ Style/TrailingComma:
     - 'app/models/confirmation.rb'
     - 'config/environments/development.rb'
     - 'lib/leaderboard_report.rb'
-    - 'lib/sendgrid_helper.rb'
     - 'spec/controllers/deferred/slots_controller_spec.rb'
     - 'spec/controllers/instant/slots_controller_spec.rb'
     - 'spec/controllers/instant/visitors_details_controller_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'sentry-raven'
 gem 'redcarpet'
 gem 'prison_staff_info', git: 'git@github.com:ministryofjustice/prison_staff_info.git', branch: 'master' unless ENV['EXCLUDE_PRIVATE_GEM']
 gem 'pg'
+gem 'sendgrid_toolkit'
 gem 'sidekiq'
 gem 'statsd-ruby', require: 'statsd'
 gem 'curb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
+    httparty (0.13.5)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     ice_nine (0.11.1)
     inflection (1.0.0)
@@ -153,6 +156,7 @@ GEM
     moj_template (0.21.0)
       rails (>= 3.1)
     multi_json (1.11.0)
+    multi_xml (0.5.5)
     multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -263,6 +267,8 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sendgrid_toolkit (1.4.0)
+      httparty (>= 0.7.6)
     sentry-raven (0.13.3)
       faraday (>= 0.7.6)
     sexp_processor (4.5.1)
@@ -364,6 +370,7 @@ DEPENDENCIES
   rubyzip
   sass-rails
   selenium-webdriver
+  sendgrid_toolkit
   sentry-raven
   sidekiq
   simplecov (~> 0.7.1)

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -15,11 +15,11 @@ class HealthcheckController < ApplicationController
   private
 
   def sendgrid_alive?
-    SendgridHelper.smtp_alive?(*VisitorMailer.smtp_settings.values_at(:address, :port))
+    SendgridApi.smtp_alive?(*VisitorMailer.smtp_settings.values_at(:address, :port))
   end
 
   def messagelabs_alive?
-    SendgridHelper.smtp_alive?(*PrisonMailer.smtp_settings.values_at(:address, :port))
+    SendgridApi.smtp_alive?(*PrisonMailer.smtp_settings.values_at(:address, :port))
   end
 
   def database_active?

--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -6,14 +6,14 @@ class SendgridApi
   def spam_reported?(email)
     return false unless can_access_sendgrid?
     spam_reports.retrieve(email: email).any?
-  rescue SendgridToolkit::APIError
+  rescue JSON::ParserError, SendgridToolkit::APIError
     false
   end
 
   def bounced?(email)
     return false unless can_access_sendgrid?
     bounces.retrieve(email: email).any?
-  rescue SendgridToolkit::APIError
+  rescue JSON::ParserError, SendgridToolkit::APIError
     false
   end
 

--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -1,46 +1,56 @@
-module SendgridHelper
-  def self.spam_reported?(email)
+class SendgridApi
+  extend SingleForwardable
+
+  def_single_delegators :new, :spam_reported?, :bounced?, :smtp_alive?
+
+  def spam_reported?(email)
     return false unless can_access_sendgrid?
-    spam_reports = SendgridToolkit::SpamReports.new(user_name, password)
     spam_reports.retrieve(email: email).any?
   rescue SendgridToolkit::APIError
     false
   end
 
-  def self.bounced?(email)
+  def bounced?(email)
     return false unless can_access_sendgrid?
-    bounces = SendgridToolkit::Bounces.new(user_name, password)
     bounces.retrieve(email: email).any?
   rescue SendgridToolkit::APIError
     false
   end
 
-  def self.smtp_alive?(host, port)
+  def smtp_alive?(host, port)
     Net::SMTP.start(host, port) do |smtp|
       smtp.enable_starttls_auto
       smtp.ehlo(Socket.gethostname)
       smtp.finish
     end
     true
-  rescue StandardError => e
+  rescue StandardError
     false
   end
 
   private
 
-  def self.can_access_sendgrid?
+  def spam_reports
+    SendgridToolkit::SpamReports.new(user_name, password)
+  end
+
+  def bounces
+    SendgridToolkit::Bounces.new(user_name, password)
+  end
+
+  def can_access_sendgrid?
     user_name && password
   end
 
-  def self.user_name
+  def user_name
     smtp_settings[:user_name]
   end
 
-  def self.password
+  def password
     smtp_settings[:password]
   end
 
-  def self.smtp_settings
+  def smtp_settings
     Rails.configuration.action_mailer.smtp_settings || {}
   end
 end

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -2,7 +2,7 @@ class EmailValidator < ActiveModel::Validator
   BAD_DOMAINS = File.readlines("data/bad_domains.txt").map(&:chomp)
 
   extend Forwardable
-  def_delegators :SendgridHelper, :bounced?, :spam_reported?
+  def_delegators :SendgridApi, :bounced?, :spam_reported?
 
   def validate(record)
     key = error_key(record)

--- a/lib/sendgrid_helper.rb
+++ b/lib/sendgrid_helper.rb
@@ -47,7 +47,7 @@ module SendgridHelper
   def self.handle_response(url)
     body = Curl::Easy.perform(url).body_str
     if response = JSON.parse(body)
-      return false if response.is_a?(Hash) && response[:error]
+      return false if response.is_a?(Hash) && response['error']
       response.size > 0
     end
   rescue Curl::Err::CurlError, JSON::ParserError => e

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HealthcheckController, type: :controller do
   let(:sendgrid_port) { double }
 
   before do
-    allow(SendgridHelper).to receive(:smtp_alive?).and_return(true)
+    allow(SendgridApi).to receive(:smtp_alive?).and_return(true)
     allow(ZENDESK_CLIENT).to receive(:tickets).and_return(double(count: 0))
   end
 
@@ -81,7 +81,7 @@ RSpec.describe HealthcheckController, type: :controller do
       allow(PrisonMailer).
         to receive(:smtp_settings).
         and_return(address: address, port: port)
-      allow(SendgridHelper).
+      allow(SendgridApi).
         to receive(:smtp_alive?).
         with(address, port).
         and_return(false)
@@ -97,7 +97,7 @@ RSpec.describe HealthcheckController, type: :controller do
       allow(VisitorMailer).
         to receive(:smtp_settings).
         and_return(address: address, port: port)
-      allow(SendgridHelper).
+      allow(SendgridApi).
         to receive(:smtp_alive?).
         with(address, port).
         and_return(false)

--- a/spec/lib/email_validator_spec.rb
+++ b/spec/lib/email_validator_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe EmailValidator do
 
   context "spam reporters" do
     it "prevents validation on an e-mail address marked as a spam reporter in sendgrid" do
-      expect(SendgridHelper).to receive(:spam_reported?).and_return(true)
+      expect(SendgridApi).to receive(:spam_reported?).and_return(true)
       expect {
         model.email = 'test@irrelevant.com'
         subject.validate(model)
@@ -94,7 +94,7 @@ RSpec.describe EmailValidator do
 
   context "bounced addresses" do
     it "prevents validation on an e-mail address marked as bounced in sendgrid" do
-      expect(SendgridHelper).to receive(:bounced?).and_return(true)
+      expect(SendgridApi).to receive(:bounced?).and_return(true)
       expect {
         model.email = 'test@irrelevant.com'
         subject.validate(model)

--- a/spec/lib/sendgrid_helper_spec.rb
+++ b/spec/lib/sendgrid_helper_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'sendgrid_helper'
 
 RSpec.describe SendgridHelper do
+  subject { described_class }
+
   context 'with sendgrid configured' do
     around do |example|
       smtp_settings = Rails.configuration.action_mailer.smtp_settings
@@ -13,93 +15,121 @@ RSpec.describe SendgridHelper do
       Rails.configuration.action_mailer.smtp_settings = smtp_settings
     end
 
-    context "spam reports" do
+    context 'spam reports' do
+      let(:body) { '[]' }
 
       before do
-        stub_request(:get,"https://sendgrid.com/api/spamreports.get.json").
+        stub_request(:get,'https://sendgrid.com/api/spamreports.get.json').
           with(query: hash_including({
-                "api_key"   => "test_smtp_password",
-                "api_user"  => "test_smtp_username",
-                "email"     => "test@example.com"})
-          ).to_return(status: 200, body: "", headers: {})
+                'api_key'   => 'test_smtp_password',
+                'api_user'  => 'test_smtp_username',
+                'email'     => 'test@example.com'})
+          ).to_return(status: 200, body: body, headers: {})
       end
 
-      context "error handling" do
-        [Curl::Err::CurlError, JSON::ParserError].each do |exception_class|
-          it "marks the email as valid if there's an error (#{exception_class})" do
-            allow(Curl::Easy).to receive(:perform).and_raise(exception_class)
-            expect(SendgridHelper.spam_reported?('test@example.com')).to be_falsey
+      context 'error handling' do
+        context 'when the API raises an exception' do
+          before do
+            allow(Curl::Easy).to receive(:perform).and_raise(Curl::Err::CurlError)
+          end
+
+          it 'has no spam report' do
+            expect(subject.spam_reported?('test@example.com')).to be_falsey
           end
         end
 
-        it "marks the email as valid when authentication fails" do
-          allow(JSON).to receive(:parse).and_return({error: 'lol'})
-          expect(SendgridHelper.spam_reported?('test@example.com')).to be_falsey
+        context 'when the API reports an error' do
+          let(:body) { '{"error":"LOL"}' }
+
+          it 'has no spam report' do
+            expect(subject.spam_reported?('test@example.com')).to be_falsey
+          end
         end
       end
 
-      context "when no error" do
-        it "marks an e-mail as valid" do
-          allow(JSON).to receive(:parse).and_return([])
-          expect(SendgridHelper.spam_reported?('test@example.com')).to be_falsey
+      context 'when no error' do
+        context 'when there is no spam report' do
+          let(:body) { '[]' }
+
+          it 'has no spam report' do
+            expect(subject.spam_reported?('test@example.com')).to be_falsey
+          end
         end
 
-        it "marks an e-mail as invalid" do
-          api_response = [
-            {
-              'ip' => '174.36.80.219',
-              'email' => 'test@example.com',
-              'created' => '2009-12-06 15:45:08'
-            }
-          ]
-          allow(JSON).to receive(:parse).and_return(api_response)
-          expect(SendgridHelper.spam_reported?('test@example.com')).to be_truthy
+        context 'when there is a spam report' do
+          let(:body) {
+            %<[
+              {
+                "ip": "174.36.80.219",
+                "email": "test@example.com",
+                "created": "2009-12-06 15:45:08"
+              }
+            ]>
+          }
+
+          it 'has a spam report' do
+            expect(subject.spam_reported?('test@example.com')).to be_truthy
+          end
         end
       end
     end
 
-    context "bounced" do
+    context 'bounced' do
+      let(:body) { '[]' }
 
       before do
-        stub_request(:get,"https://sendgrid.com/api/bounces.get.json").
+        stub_request(:get,'https://sendgrid.com/api/bounces.get.json').
           with(query: hash_including({
-                "api_key"   => "test_smtp_password",
-                "api_user"  => "test_smtp_username",
-                "email"     => "test@example.com"})
-          ).to_return(status: 200, body: "", headers: {})
+                'api_key'   => 'test_smtp_password',
+                'api_user'  => 'test_smtp_username',
+                'email'     => 'test@example.com'})
+          ).to_return(status: 200, body: body, headers: {})
       end
 
-      context "error handling" do
-        [Curl::Err::CurlError, JSON::ParserError].each do |exception_class|
-          it "marks the email as valid if there's an error (#{exception_class})" do
-            allow(Curl::Easy).to receive(:perform).and_raise(exception_class)
-            expect(SendgridHelper.bounced?('test@example.com')).to be_falsey
+      context 'error handling' do
+        context 'when the API raises an exception' do
+          before do
+            allow(Curl::Easy).to receive(:perform).and_raise(Curl::Err::CurlError)
+          end
+
+          it 'has no bounce' do
+            expect(subject.bounced?('test@example.com')).to be_falsey
           end
         end
 
-        it "marks the email as valid when authentication fails" do
-          allow(JSON).to receive(:parse).and_return({error: 'lol'})
-          expect(SendgridHelper.bounced?('test@example.com')).to be_falsey
+        context 'when the API reports an error' do
+          let(:body) { '{"error":"LOL"}' }
+
+          it 'has no bounce' do
+            expect(subject.bounced?('test@example.com')).to be_falsey
+          end
         end
       end
 
-      context "when no error" do
-        it "marks an e-mail as valid" do
-          allow(JSON).to receive(:parse).and_return([])
-          expect(SendgridHelper.bounced?('test@example.com')).to be_falsey
+      context 'when no error' do
+        context 'when there is no bounce' do
+          let(:body) { '[]' }
+
+          it 'has no bounce' do
+            expect(subject.bounced?('test@example.com')).to be_falsey
+          end
         end
 
-        it "marks an e-mail as invalid" do
-          api_response = [
-            {
-              'status' => '4.0.0',
-              'created' => '2011-09-16 22:02:19',
-              'reason' => 'Unable to resolve MX host example.com',
-              'email' => 'test@example.com'
-            }
-          ]
-          allow(JSON).to receive(:parse).and_return(api_response)
-          expect(SendgridHelper.bounced?('test@example.com')).to be_truthy
+        context 'when there is a bounce' do
+          let(:body) {
+            %<[
+              {
+                "status": "4.0.0",
+                "created": "2011-09-16 22:02:19",
+                "reason": "Unable to resolve MX host example.com",
+                "email": "test@example.com"
+              }
+            ]>
+          }
+
+          it 'has a bounce' do
+            expect(subject.bounced?('test@example.com')).to be_truthy
+          end
         end
       end
     end
@@ -115,28 +145,28 @@ RSpec.describe SendgridHelper do
 
     context 'bounced?' do
       it 'never says that the email has bounced' do
-        expect(SendgridHelper.bounced?('test@example.com')).to be_falsey
+        expect(subject.bounced?('test@example.com')).to be_falsey
       end
 
       it 'does not talk to sendgrid' do
         expect(Curl::Easy).to receive(:perform).never
-        SendgridHelper.bounced?('test@example.com')
+        subject.bounced?('test@example.com')
       end
     end
 
     context 'spam_reported?' do
       it 'never says that the email address has been reported for spam' do
-        expect(SendgridHelper.spam_reported?('test@example.com')).to be_falsey
+        expect(subject.spam_reported?('test@example.com')).to be_falsey
       end
 
       it 'does not talk to sendgrid' do
         expect(Curl::Easy).to receive(:perform).never
-        SendgridHelper.spam_reported?('test@example.com')
+        subject.spam_reported?('test@example.com')
       end
     end
   end
 
-  context "sendgrid connection test" do
+  context 'sendgrid connection test' do
     let :host do
       'smtp.sendgrid.net'
     end
@@ -145,31 +175,31 @@ RSpec.describe SendgridHelper do
       587
     end
 
-    context "when it connects" do
-      it "will return true" do
+    context 'when it connects' do
+      it 'will return true' do
         expect(Net::SMTP).to receive(:start)
-        expect(SendgridHelper.smtp_alive?(host, port)).to be_truthy
+        expect(subject.smtp_alive?(host, port)).to be_truthy
       end
     end
 
-    context "when it times out" do
-      it "will return false" do
+    context 'when it times out' do
+      it 'will return false' do
         expect(Net::SMTP).to receive(:start).and_raise(Net::OpenTimeout)
-        expect(SendgridHelper.smtp_alive?(host, port)).to be_falsey
+        expect(subject.smtp_alive?(host, port)).to be_falsey
       end
     end
 
-    context "when the port is closed" do
-      it "will return false" do
+    context 'when the port is closed' do
+      it 'will return false' do
         expect(Net::SMTP).to receive(:start).and_raise(Errno::ECONNREFUSED)
-        expect(SendgridHelper.smtp_alive?(host, port)).to be_falsey
+        expect(subject.smtp_alive?(host, port)).to be_falsey
       end
     end
 
-    context "when the hostname cannot be resolved" do
-      it "will return false" do
+    context 'when the hostname cannot be resolved' do
+      it 'will return false' do
         expect(Net::SMTP).to receive(:start).and_raise(SocketError)
-        expect(SendgridHelper.smtp_alive?(host, port)).to be_falsey
+        expect(subject.smtp_alive?(host, port)).to be_falsey
       end
     end
   end

--- a/spec/lib/sendgrid_helper_spec.rb
+++ b/spec/lib/sendgrid_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SendgridHelper do
       let(:body) { '[]' }
 
       before do
-        stub_request(:get,'https://sendgrid.com/api/spamreports.get.json').
+        stub_request(:post, 'https://api.sendgrid.com/api/spamreports.get.json').
           with(query: hash_including({
                 'api_key'   => 'test_smtp_password',
                 'api_user'  => 'test_smtp_username',
@@ -30,7 +30,8 @@ RSpec.describe SendgridHelper do
       context 'error handling' do
         context 'when the API raises an exception' do
           before do
-            allow(Curl::Easy).to receive(:perform).and_raise(Curl::Err::CurlError)
+            stub_request(:post, 'https://api.sendgrid.com/api/spamreports.get.json').
+              to_raise(StandardError)
           end
 
           it 'has no spam report' do
@@ -78,7 +79,7 @@ RSpec.describe SendgridHelper do
       let(:body) { '[]' }
 
       before do
-        stub_request(:get,'https://sendgrid.com/api/bounces.get.json').
+        stub_request(:post,'https://api.sendgrid.com/api/bounces.get.json').
           with(query: hash_including({
                 'api_key'   => 'test_smtp_password',
                 'api_user'  => 'test_smtp_username',
@@ -89,7 +90,8 @@ RSpec.describe SendgridHelper do
       context 'error handling' do
         context 'when the API raises an exception' do
           before do
-            allow(Curl::Easy).to receive(:perform).and_raise(Curl::Err::CurlError)
+            stub_request(:post, 'https://api.sendgrid.com/api/bounces.get.json').
+              to_raise(StandardError)
           end
 
           it 'has no bounce' do
@@ -149,7 +151,7 @@ RSpec.describe SendgridHelper do
       end
 
       it 'does not talk to sendgrid' do
-        expect(Curl::Easy).to receive(:perform).never
+        expect(HTTParty).to receive(:post).never
         subject.bounced?('test@example.com')
       end
     end
@@ -160,7 +162,7 @@ RSpec.describe SendgridHelper do
       end
 
       it 'does not talk to sendgrid' do
-        expect(Curl::Easy).to receive(:perform).never
+        expect(HTTParty).to receive(:post).never
         subject.spam_reported?('test@example.com')
       end
     end

--- a/spec/services/sendgrid_api_spec.rb
+++ b/spec/services/sendgrid_api_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
-require 'sendgrid_helper'
 
-RSpec.describe SendgridHelper do
-  subject { described_class }
+RSpec.describe SendgridApi do
+  subject { described_class.new }
 
   context 'with sendgrid configured' do
     around do |example|
@@ -20,11 +19,11 @@ RSpec.describe SendgridHelper do
 
       before do
         stub_request(:post, 'https://api.sendgrid.com/api/spamreports.get.json').
-          with(query: hash_including({
-                'api_key'   => 'test_smtp_password',
-                'api_user'  => 'test_smtp_username',
-                'email'     => 'test@example.com'})
-          ).to_return(status: 200, body: body, headers: {})
+          with(query: hash_including(
+            'api_key'   => 'test_smtp_password',
+            'api_user'  => 'test_smtp_username',
+            'email'     => 'test@example.com')).
+          to_return(status: 200, body: body, headers: {})
       end
 
       context 'error handling' do
@@ -59,13 +58,13 @@ RSpec.describe SendgridHelper do
 
         context 'when there is a spam report' do
           let(:body) {
-            %<[
+            %([
               {
                 "ip": "174.36.80.219",
                 "email": "test@example.com",
                 "created": "2009-12-06 15:45:08"
               }
-            ]>
+            ])
           }
 
           it 'has a spam report' do
@@ -79,12 +78,12 @@ RSpec.describe SendgridHelper do
       let(:body) { '[]' }
 
       before do
-        stub_request(:post,'https://api.sendgrid.com/api/bounces.get.json').
-          with(query: hash_including({
-                'api_key'   => 'test_smtp_password',
-                'api_user'  => 'test_smtp_username',
-                'email'     => 'test@example.com'})
-          ).to_return(status: 200, body: body, headers: {})
+        stub_request(:post, 'https://api.sendgrid.com/api/bounces.get.json').
+          with(query: hash_including(
+            'api_key'   => 'test_smtp_password',
+            'api_user'  => 'test_smtp_username',
+            'email'     => 'test@example.com')).
+          to_return(status: 200, body: body, headers: {})
       end
 
       context 'error handling' do
@@ -119,14 +118,14 @@ RSpec.describe SendgridHelper do
 
         context 'when there is a bounce' do
           let(:body) {
-            %<[
+            %([
               {
                 "status": "4.0.0",
                 "created": "2011-09-16 22:02:19",
                 "reason": "Unable to resolve MX host example.com",
                 "email": "test@example.com"
               }
-            ]>
+            ])
           }
 
           it 'has a bounce' do

--- a/spec/services/sendgrid_api_spec.rb
+++ b/spec/services/sendgrid_api_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe SendgridApi do
             expect(subject.spam_reported?('test@example.com')).to be_falsey
           end
         end
+
+        context 'when the API returns non-JSON' do
+          let(:body) { 'Oopsy daisy' }
+
+          it 'has no spam report' do
+            expect(subject.spam_reported?('test@example.com')).to be_falsey
+          end
+        end
       end
 
       context 'when no error' do
@@ -100,6 +108,14 @@ RSpec.describe SendgridApi do
 
         context 'when the API reports an error' do
           let(:body) { '{"error":"LOL"}' }
+
+          it 'has no bounce' do
+            expect(subject.bounced?('test@example.com')).to be_falsey
+          end
+        end
+
+        context 'when the API returns non-JSON' do
+          let(:body) { 'Oopsy daisy' }
 
           it 'has no bounce' do
             expect(subject.bounced?('test@example.com')).to be_falsey


### PR DESCRIPTION
There exists a gem for integrating with Sendgrid's API: [sendgrid_toolkit](https://github.com/freerobby/sendgrid_toolkit). So let's not rewrite it.

For the existing API integration, this PR represents just a slight improvement in terseness, but it provides a good basis for adding new actions.

`SendgridHelper` is now `SendgridApi`, a thin layer that preserves the existing interface whilst using `sendgrid_toolkit` underneath. This is a minimal change in terms of testing and interface, but we should now be confident enough that we only test that we're using the `sendgrid_toolkit` API correctly in future.