### PR TITLE
Make session timeout longer in development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,6 @@ module PrisonVisits2
     config.autoload_paths += %w(lib app/mailers/concerns)
     config.assets.paths << Rails.root.join('vendor', 'assets', 'moj.slot-picker', 'dist', 'stylesheets')
     config.middleware.delete 'ActiveRecord::QueryCache'
+    config.session_expire_after = 20.minutes
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,4 +14,5 @@ PrisonVisits2::Application.configure do
   config.active_job.queue_adapter = :sidekiq
   config.smoke_test_email_local_part = ENV['SMOKE_TEST_EMAIL_LOCAL_PART']
   config.smoke_test_email_domain = ENV['SMOKE_TEST_EMAIL_DOMAIN']
+  config.session_expire_after = 24.hours
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,7 +3,7 @@ SERVICE_DOMAIN = (service_url) ? URI.parse(service_url).host : nil
 
 PrisonVisits2::Application.config.session_store :cookie_store,
   key: 'pvbs',
-  expire_after: 20.minutes,
+  expire_after: Rails.configuration.session_expire_after,
   httponly: true,
   domain: SERVICE_DOMAIN,
   secure: Rails.env.production?

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -5,6 +5,5 @@ PrisonVisits2::Application.config.session_store :cookie_store,
   key: 'pvbs',
   expire_after: 20.minutes,
   httponly: true,
-  max_age: 20.minutes,
   domain: SERVICE_DOMAIN,
   secure: Rails.env.production?

--- a/spec/configuration/session_cookie_spec.rb
+++ b/spec/configuration/session_cookie_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe PrisonVisits2::Application.config do
   it "sets a cookie with the right parameters" do
     expect(subject.session_store).to eq(ActionDispatch::Session::CookieStore)
     # secure: false -> true gets set by the initializer.
-    expect(subject.session_options).to eq({key: "pvbs", expire_after: 20.minutes, httponly: true, cookie_only: true, secure: false, max_age: 1200, domain: nil})
+    expect(subject.session_options).to eq({key: "pvbs", expire_after: 20.minutes, httponly: true, cookie_only: true, secure: false, domain: nil})
   end
 end

--- a/spec/configuration/session_cookie_spec.rb
+++ b/spec/configuration/session_cookie_spec.rb
@@ -1,9 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe PrisonVisits2::Application.config do
-  it "sets a cookie with the right parameters" do
+  it "uses the session cookie store" do
     expect(subject.session_store).to eq(ActionDispatch::Session::CookieStore)
-    # secure: false -> true gets set by the initializer.
-    expect(subject.session_options).to eq({key: "pvbs", expire_after: 20.minutes, httponly: true, cookie_only: true, secure: false, domain: nil})
+  end
+
+  it "uses pvbs as key" do
+    expect(subject.session_options).to include(key: "pvbs")
+  end
+
+  it "sets the session expiry" do
+    expect(subject.session_options).to include(expire_after: 20.minutes)
   end
 end


### PR DESCRIPTION
Now the session timeout is 20 minutes for staging and production,
but for the development is 24 hours so its less aggressive now.