### PR TITLE
Make `/` only route to start page on prod

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,5 +68,5 @@ PrisonVisits2::Application.routes.draw do
   # Legacy URLs
   get "/prisoner-details", to: redirect("/prisoner")
 
-  get "/", to: redirect(ENV["GOVUK_START_PAGE"] || "https://www.gov.uk/prison-visits")
+  get "/", to: redirect(ENV.fetch("GOVUK_START_PAGE", "/prisoner"))
 end


### PR DESCRIPTION
We change route so it doesn't redirect to the live environment in the
dev environment.