### PR TITLE
Remove /deferred from the tested paths

### DIFF
--- a/smoke_test/steps/check_your_request_page.rb
+++ b/smoke_test/steps/check_your_request_page.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class CheckYourRequestPage < BaseStep
-      PAGE_PATH = '/deferred/visit'
+      PAGE_PATH = '/visit'
 
       def validate!
         if page.current_path != PAGE_PATH

--- a/smoke_test/steps/process_visit_request_page.rb
+++ b/smoke_test/steps/process_visit_request_page.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class ProcessVisitRequestPage < BaseStep
-      PAGE_PATH = '/deferred/confirmation/new'
+      PAGE_PATH = '/confirmation/new'
 
       def validate!
         if page.current_path != PAGE_PATH

--- a/smoke_test/steps/slots_page.rb
+++ b/smoke_test/steps/slots_page.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class SlotsPage < BaseStep
-      PAGE_PATH = '/deferred/slots'
+      PAGE_PATH = '/slots'
 
       def validate!
         if page.current_path != PAGE_PATH

--- a/smoke_test/steps/visitors_page.rb
+++ b/smoke_test/steps/visitors_page.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class VisitorsPage < BaseStep
-      PAGE_PATH = '/deferred/visitors'
+      PAGE_PATH = '/visitors'
 
       def validate!
         if page.current_path != PAGE_PATH


### PR DESCRIPTION
This was removed from master last week.  It got missed from the smoke
tests because the branch had not been merged at the time.