### PR TITLE
Change timeouts to account for sidekiq queue

### DIFF
--- a/smoke_test/steps/base_step.rb
+++ b/smoke_test/steps/base_step.rb
@@ -24,7 +24,7 @@ module SmokeTest
         self.class.name.split('::').last.gsub(/(?=[A-Z])/, ' ')
       end
 
-      def with_retries(attempts: 5, initial_delay: 2, max_delay: 30)
+      def with_retries(attempts: 10, initial_delay: 2, max_delay: 120)
         delay = initial_delay
         result = nil
         attempts.times do


### PR DESCRIPTION
This has changed the amount of time it takes for an email to get through
the system, resulting in smoke test timeouts.  This change should fix
that.