### PR TITLE
Don't run SimpleCov for only one file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ else
   require 'simplecov'
   require 'simplecov-rcov'
   SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start 'rails' do
-    add_filter '/gem/'
-  end
 end
 
 RSpec.configure do |config|
@@ -27,6 +24,10 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   if config.files_to_run.one?
     config.default_formatter = 'doc'
+  else
+    SimpleCov.start 'rails' do
+      add_filter '/gem/'
+    end
   end
   config.profile_examples = 10
   config.order = :random


### PR DESCRIPTION
Running the coverage report takes time, but is not useful when running a single spec. In order to allow faster iteration, let's skip the report when there's only one spec file to run.

This is an alternative to #348 that might be more generally useful.