### PR TITLE
Fix incorrect input validation on age fields

### DIFF
--- a/app/models/concerns/person.rb
+++ b/app/models/concerns/person.rb
@@ -36,7 +36,7 @@ module Person
   end
 
   def maximum_date_of_birth
-    Time.zone.today
+    Time.zone.today.end_of_year
   end
 
   private

--- a/spec/models/concerns/person_spec.rb
+++ b/spec/models/concerns/person_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Person do
+  let(:klass) {
+    Class.new.tap { |c|
+      c.send :include, NonPersistedModel
+      c.send :include, described_class
+    }
+  }
+
+  subject { klass.new }
+
+  around do |example|
+    Timecop.travel Date.new(2015, 10, 8) do
+      example.run
+    end
+  end
+
+  describe 'minimum_date_of_birth' do
+    it 'gives a day of 1st' do
+      expect(subject.minimum_date_of_birth.day).to eq(1)
+    end
+
+    it 'gives a month of January' do
+      expect(subject.minimum_date_of_birth.month).to eq(1)
+    end
+
+    it 'gives a year of 120 years ago' do
+      expect(subject.minimum_date_of_birth.year).to eq(1895)
+    end
+  end
+
+  describe 'maximum_date_of_birth' do
+    it 'gives a day of 31st' do
+      expect(subject.maximum_date_of_birth.day).to eq(31)
+    end
+
+    it 'gives a month of December' do
+      expect(subject.maximum_date_of_birth.month).to eq(12)
+    end
+
+    it 'gives a year of this year' do
+      expect(subject.maximum_date_of_birth.year).to eq(2015)
+    end
+  end
+end


### PR DESCRIPTION
The maximum value for date input fields (enforced in modern browsers) was incorrectly calculated as 120 years ago from today, and not the end of the year. This meant that, for example, on 9 October, dates with a day greater than 9 or a month greater than 10 could not be entered.