### PR TITLE
Change date format

### DIFF
--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -109,6 +109,6 @@ class PrisonMailer < ActionMailer::Base
   end
 
   def formatted_first_slot_date
-    I18n.l(Date.parse(@visit.slots.first.date), format: :day_and_date)
+    I18n.l(Date.parse(@visit.slots.first.date), format: :long)
   end
 end

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -72,6 +72,6 @@ class VisitorMailer < ActionMailer::Base
   end
 
   def format_date(date)
-    I18n.l(date, format: :day_date_and_year)
+    I18n.l(date, format: :long)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,8 +2,7 @@ en:
   date:
     formats:
       default: "%d/%m/%Y"
-      day_and_date: "%A %e %B"
-      day_date_and_year: "%-d %B %Y"
+      long: "%A %-d %B %Y"
     fields:
       day: Day
       month: Month

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit confirmed: your visit for 7 July 2013 has been confirmed",
+                "Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed",
                 "COPY of booking confirmation for Jimmy Harris"
               ]
             )
@@ -123,7 +123,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )
@@ -142,7 +142,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )
@@ -159,7 +159,7 @@ RSpec.describe ConfirmationsController, type: :controller do
           after do
             post :create, confirmation: { outcome: Confirmation::NO_SLOT_AVAILABLE }, state: encrypted_visit
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
-            expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(["Visit cannot take place: your visit for 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"])
+            expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(["Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked", "COPY of booking rejection for Jimmy Harris"])
           end
         end
 
@@ -218,7 +218,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit confirmed: your visit for 7 July 2013 has been confirmed",
+                "Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed",
                 "COPY of booking confirmation for Jimmy Harris"
               ]
             )
@@ -267,7 +267,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit confirmed: your visit for 7 July 2013 has been confirmed",
+                "Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed",
                 "COPY of booking confirmation for Jimmy Harris"
               ]
             )
@@ -313,7 +313,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )
@@ -358,7 +358,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )
@@ -382,7 +382,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )
@@ -406,7 +406,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )
@@ -430,7 +430,7 @@ RSpec.describe ConfirmationsController, type: :controller do
             expect(response).to redirect_to(show_confirmation_path(visit_id: visit.visit_id))
             expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(
               [
-                "Visit cannot take place: your visit for 7 July 2013 could not be booked",
+                "Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked",
                 "COPY of booking rejection for Jimmy Harris"
               ]
             )

--- a/spec/controllers/visit_controller_spec.rb
+++ b/spec/controllers/visit_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe VisitController, type: :controller do
     it "cancels a confirmed visit request" do
       expect(controller.metrics_logger).to receive(:visit_status).with(sample_visit.visit_id).and_return('confirmed')
       post :update_status, id: sample_visit.visit_id, state: encrypted_visit, cancel: true
-      expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(['CANCELLED: Jimmy Harris on Sunday 7 July'])
+      expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(['CANCELLED: Jimmy Harris on Sunday 7 July 2013'])
     end
 
     after :each do

--- a/spec/controllers/visits_controller_spec.rb
+++ b/spec/controllers/visits_controller_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe VisitsController, type: :controller do
       post :update
       expect(response).to redirect_to(show_visit_path(state: state))
 
-      expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(['Visit request for Jimmy Harris on Friday 6 December',
-                                                              "Not booked yet: we've received your visit request for 6 December 2013"])
+      expect(ActionMailer::Base.deliveries.map(&:subject)).to eq(['Visit request for Jimmy Harris on Friday 6 December 2013',
+                                                              "Not booked yet: we've received your visit request for Friday 6 December 2013"])
     end
 
     it "displays the final page" do

--- a/spec/mailers/prison_mailer_spec.rb
+++ b/spec/mailers/prison_mailer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe PrisonMailer do
 
   context "always" do
     it "sends an e-mail with the prisoner name in the subject" do
-      expect(subject.booking_request_email(sample_visit, "token").subject).to eq('Visit request for Jimmy Harris on Sunday 7 July')
+      expect(subject.booking_request_email(sample_visit, "token").subject).to eq('Visit request for Jimmy Harris on Sunday 7 July 2013')
     end
 
     it "sends an e-mail with a long link to the confirmation page" do
@@ -120,7 +120,7 @@ RSpec.describe PrisonMailer do
       subject.booking_cancellation_receipt_email(sample_visit).tap do |email|
         expect(email['X-Priority'].value).to eq('1 (Highest)')
         expect(email['X-MSMail-Priority'].value).to eq('High')
-        expect(email.subject).to eq('CANCELLED: Jimmy Harris on Sunday 7 July')
+        expect(email.subject).to eq('CANCELLED: Jimmy Harris on Sunday 7 July 2013')
         expect(email).to match_in_text('a0000aa')
         expect(email).to match_in_text(sample_visit.visit_id)
         expect(email).to match_in_text('87654321')

--- a/spec/mailers/visitor_mailer_spec.rb
+++ b/spec/mailers/visitor_mailer_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail" do
         email = subject.booking_confirmation_email(sample_visit, confirmation, token)
-        expect(email.subject).to eq("Visit confirmed: your visit for 7 July 2013 has been confirmed")
+        expect(email.subject).to eq("Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -152,7 +152,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail with a reference number (canned responses)" do
         email = subject.booking_confirmation_email(sample_visit, confirmation_canned_response, token)
-        expect(email.subject).to eq("Visit confirmed: your visit for 7 July 2013 has been confirmed")
+        expect(email.subject).to eq("Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -170,7 +170,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail with no reference number for remand prisoners (canned responses)" do
         email = subject.booking_confirmation_email(sample_visit, confirmation_canned_response_remand, token)
-        expect(email.subject).to eq("Visit confirmed: your visit for 7 July 2013 has been confirmed")
+        expect(email.subject).to eq("Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -187,7 +187,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail with the list of visitors not on the approved visitor list" do
         email = subject.booking_confirmation_email(sample_visit, confirmation_unlisted_visitors, token)
-        expect(email.subject).to eq("Visit confirmed: your visit for 7 July 2013 has been confirmed")
+        expect(email.subject).to eq("Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -205,7 +205,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail with the list of banned visitors" do
         email = subject.booking_confirmation_email(sample_visit, confirmation_banned_visitors, token)
-        expect(email.subject).to eq("Visit confirmed: your visit for 7 July 2013 has been confirmed")
+        expect(email.subject).to eq("Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -223,7 +223,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail notifying visitors that it is a closed visit" do
         email = subject.booking_confirmation_email(sample_visit, confirmation_closed_visit, token)
-        expect(email.subject).to eq("Visit confirmed: your visit for 7 July 2013 has been confirmed")
+        expect(email.subject).to eq("Visit confirmed: your visit for Sunday 7 July 2013 has been confirmed")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -251,7 +251,7 @@ RSpec.describe VisitorMailer do
 
       it "because of a slot not being available" do
         email = subject.booking_rejection_email(sample_visit, confirmation_no_slot_available)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -267,7 +267,7 @@ RSpec.describe VisitorMailer do
 
       it "because of a visitor not being on a contact list (legacy)" do
         email = subject.booking_rejection_email(sample_visit, confirmation_not_on_contact_list)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -283,7 +283,7 @@ RSpec.describe VisitorMailer do
 
       it "because the prisoner details are incorrect" do
         email = subject.booking_rejection_email(sample_visit, rejection_prisoner_incorrect)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -300,7 +300,7 @@ RSpec.describe VisitorMailer do
 
       it "because the prisoner is not at the prison" do
         email = subject.booking_rejection_email(sample_visit, rejection_prisoner_not_present)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -317,7 +317,7 @@ RSpec.describe VisitorMailer do
 
       it "because the prisoner has no allowance" do
         email = subject.booking_rejection_email(sample_visit, rejection_prisoner_no_allowance)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -334,7 +334,7 @@ RSpec.describe VisitorMailer do
 
       it "because the prisoner has no allowance and a VO renewal date is specified" do
         email = subject.booking_rejection_email(sample_visit, rejection_prisoner_no_allowance_vo_renew)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -352,7 +352,7 @@ RSpec.describe VisitorMailer do
 
       it "because the prisoner has no allowance and a PVO renewal date is specified" do
         email = subject.booking_rejection_email(sample_visit, rejection_prisoner_no_allowance_pvo_renew)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -371,7 +371,7 @@ RSpec.describe VisitorMailer do
 
       it "because a visitor is not on the list (canned response)" do
         email = subject.booking_rejection_email(sample_visit, rejection_visitor_not_listed)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -388,7 +388,7 @@ RSpec.describe VisitorMailer do
 
       it "because a visitor is banned" do
         email = subject.booking_rejection_email(sample_visit, rejection_visitor_banned)
-        expect(email.subject).to eq("Visit cannot take place: your visit for 7 July 2013 could not be booked")
+        expect(email.subject).to eq("Visit cannot take place: your visit for Sunday 7 July 2013 could not be booked")
 
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
@@ -412,7 +412,7 @@ RSpec.describe VisitorMailer do
 
       it "sends out an e-mail with a date in the subject" do
         email = subject.booking_receipt_email(sample_visit, "token")
-        expect(email.subject).to eq("Not booked yet: we've received your visit request for 7 July 2013")
+        expect(email.subject).to eq("Not booked yet: we've received your visit request for Sunday 7 July 2013")
         expect(email[:from]).to eq(noreply_address)
         expect(email[:reply_to]).to eq(prison_address)
         expect(email[:to]).to eq(visitor_address)


### PR DESCRIPTION
Date format changed for both 'prison_mailer' and 'visitor_mailer' to
be (full weekday name, day of the month, full month name and year).
So both of them have the same date format and give all the necessary
details