### PR TITLE
Record an event when an input fails validation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,7 @@
 //= require modules/moj.Conditional
 //= require modules/moj.checkbox-summary
 //= require modules/moj.AgeLabel.js
+//= require modules/moj.form-errors
 
 // Assets without a better place
 //= require shame

--- a/app/assets/javascripts/modules/moj.form-errors.js
+++ b/app/assets/javascripts/modules/moj.form-errors.js
@@ -1,0 +1,25 @@
+(function () {
+  'use strict';
+
+  document.addEventListener(
+    'invalid',
+    function(e){
+      if (e.target.tagName !== 'INPUT') { return; }
+
+      var payload = {
+        event: {
+          type: 'invalid',
+          pathname: document.location.pathname,
+          element: e.target.name
+        }
+      };
+
+      var csrf_param = $('meta[name=csrf-param]').attr('content');
+      var csrf_token = $('meta[name=csrf-token]').attr('content');
+      payload[csrf_param] = csrf_token;
+
+      $.post('/frontend_events', payload);
+    },
+    true
+  );
+}());

--- a/app/controllers/frontend_events_controller.rb
+++ b/app/controllers/frontend_events_controller.rb
@@ -1,0 +1,5 @@
+class FrontendEventsController < ApplicationController
+  def create
+    render json: {}
+  end
+end

--- a/app/views/prisoner_details/_dob.html.erb
+++ b/app/views/prisoner_details/_dob.html.erb
@@ -7,12 +7,11 @@
       class="form-control"
       value="<%=
         prisoner.date_of_birth ?
-          prisoner.date_of_birth.send(field_name).to_s.rjust(2, '0') : ''
+          prisoner.date_of_birth.send(field_name) : ''
         %>"
       type="number"
       min="<%= prisoner.minimum_date_of_birth.send(field_name) %>"
       max="<%= prisoner.maximum_date_of_birth.send(field_name) %>"
-      pattern="[0-9]*"
       name="prisoner[date_of_birth(<%= i %>i)]"
       id="prisoner_date_of_birth_<%= i %>i"
       aria-describedby="dobHint"

--- a/app/views/shared/visitors_details/_dob.html.erb
+++ b/app/views/shared/visitors_details/_dob.html.erb
@@ -7,12 +7,11 @@
       class="form-control <%= field_name %>"
       value="<%=
         visitor.date_of_birth && !js_template ?
-          visitor.date_of_birth.send(field_name).to_s.rjust(2, '0') : ''
+          visitor.date_of_birth.send(field_name) : ''
         %>"
       type="number"
       min="<%= visitor.minimum_date_of_birth.send(field_name) %>"
       max="<%= visitor.maximum_date_of_birth.send(field_name) %>"
-      pattern="[0-9]*",
       name="visit[visitor][][date_of_birth(<%= i %>i)]"
       id="visitor_date_of_birth_<%= i %>i_<%= index %>"
       aria-describedby="dobHint"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ PrisonVisits2::Application.routes.draw do
 
   resource :feedback
 
+  resources :frontend_events, only: [:create]
+
   get 'prisoner'           => 'prisoner_details#edit', as: :edit_prisoner_details
   post 'prisoner'          => 'prisoner_details#update', as: :prisoner_details
 

--- a/spec/controllers/frontend_events_controller_spec.rb
+++ b/spec/controllers/frontend_events_controller_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe FrontendEventsController, type: :controller do
+  it "returns a success response" do
+    post :create, event: { type: 'dummy' }
+    expect(response).to be_success
+  end
+end


### PR DESCRIPTION
We don't have any visibility of what happens when a visitor's browser prevents them from submitting a form because an input failed validation, so we don't know when we have inadvertently locked them out.

The HTML5 form validation API exposes an 'invalid' event that we can listen for. We can then POST back to the server with some salient details (path and field name) so that we can monitor and graph these over time, and be aware of spikes that indicate when we've messed up.

Logstasher will record the parameters, and this can be viewed in Kibana with a query like:

    (type:pvb AND path:"/frontend_events")

Unfortunately, PhantomJS does not respond to the 'invalid' event, so we can't actually test this except by manual means. Sad times.