### PR TITLE
Rename METRICS_AUTH_KEY_NAME

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   end
 
   def reject_without_key_or_trusted_ip!
-    unless valid_auth_key? || permitted_ip?
+    unless valid_trusted_users_access_key? || permitted_ip?
       raise ActionController::RoutingError.new('Not Found')
     end
   end
@@ -19,15 +19,15 @@ class ApplicationController < ActionController::Base
       include?(request.remote_ip)
   end
 
-  def auth_key
-    Rails.configuration.metrics_auth_key
+  def trusted_users_access_key
+    Rails.configuration.trusted_users_access_key
   end
 
-  def valid_auth_key?
+  def valid_trusted_users_access_key?
     pad_execution_time 0.1 do
-      auth_key &&
+      trusted_users_access_key &&
         params[:key] &&
-        auth_key == params[:key]
+        trusted_users_access_key == params[:key]
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,7 +41,7 @@ module PrisonVisits2
             fetch('england-and-wales').
             fetch('events').
             map { |event| Date.parse(event['date']) }
-    config.metrics_auth_key = ENV['METRICS_AUTH_KEY']
+    config.trusted_users_access_key = ENV['TRUSTED_USERS_ACCESS_KEY']
     config.permitted_ips_for_confirmations =
       (ENV['PRISON_ESTATE_IPS'] || '').split(',')
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     before :each do
-      allow(Rails.configuration).to receive(:metrics_auth_key).and_return('lulz')
+      allow(Rails.configuration).to receive(:trusted_users_access_key).and_return('lulz')
       controller.class.permit_only_trusted_users
     end
 
@@ -87,7 +87,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     before :each do
       controller.class.permit_only_trusted_users
-      Rails.configuration.metrics_auth_key = "VALID"
+      Rails.configuration.trusted_users_access_key = "VALID"
     end
 
     it "accepts clients with key" do

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe HealthcheckController, type: :controller do
   let(:key) { 'super secret' }
 
   around do |example|
-    original = Rails.configuration.metrics_auth_key
-    Rails.configuration.metrics_auth_key = key
+    original = Rails.configuration.trusted_users_access_key
+    Rails.configuration.trusted_users_access_key = key
     example.call
-    Rails.configuration.metrics_auth_key = original
+    Rails.configuration.trusted_users_access_key = original
   end
 
   let(:parsed_body) {


### PR DESCRIPTION
We rename ENV['METRICS_AUTH_KEY'] to ENV['TRUSTED_USERS_ACCESS_KEY']
so we can have better idea what it is for.