### PR TITLE
Remove legacy data fixes

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -67,8 +67,7 @@ class ConfirmationsController < ApplicationController
   end
 
   def booked_visit
-    @booked_visit ||=
-      legacy_data_fixes(encryptor.decrypt_and_verify(params[:state]))
+    @booked_visit ||= encryptor.decrypt_and_verify(params[:state])
   end
 
   private
@@ -86,25 +85,6 @@ class ConfirmationsController < ApplicationController
       :outcome, :message, :vo_number, :no_vo, :no_pvo, :renew_vo,
       :renew_pvo, :closed_visit, :visitor_not_listed, :visitor_banned,
       :canned_response, banned_visitors: [], unlisted_visitors: [])
-  end
-
-  LEGACY_PRISON_NAMES = {
-    'Hollesley Bay'                     => 'Hollesley Bay Open',
-    'Hatfield (moorland Open)'          => 'Hatfield Open',
-    'Highpoint'                         => 'Highpoint North',
-    'Albany'                            => 'Isle of Wight - Albany',
-    'Parkhurst'                         => 'Isle of Wight - Parkhurst',
-    'Liverpool (Open only)'             => 'Liverpool Social Visits',
-    'Hindley (Young Adult 18-21 only)'  => 'Hindley',
-    'Hindley (Young People 15-18 only)' => 'Hindley'
-  }
-
-  def legacy_data_fixes(visit)
-    if LEGACY_PRISON_NAMES.key?(visit.prison_name)
-      STATSD_CLIENT.increment('pvb.app.legacy_data_fixes')
-      visit.prison_name = LEGACY_PRISON_NAMES[visit.prison_name]
-    end
-    visit
   end
 
   def remove_unused_slots(visit, slot_index)

--- a/spec/controllers/confirmations_controller_spec.rb
+++ b/spec/controllers/confirmations_controller_spec.rb
@@ -51,23 +51,6 @@ RSpec.describe ConfirmationsController, type: :controller do
         expect(response).to render_template('confirmations/_already_booked')
       end
 
-      ['Hollesley Bay', 'Hatfield (moorland Open)', 'Highpoint', 'Albany', 'Parkhurst', 'Liverpool (Open only)'].each do |prison_name|
-        it "resurrects a visit with a old prison name (#{prison_name}) to avoid a runtime exception" do
-          visit.prison_name = prison_name
-          expect(controller).to receive(:logstasher_add_visit_id).with(visit.visit_id)
-          expect(mock_metrics_logger).to receive(:request_cancelled?).and_return(false)
-          expect(mock_metrics_logger).to receive(:record_link_click)
-          expect(mock_metrics_logger).to receive(:processed?) do |v|
-            expect(v).to be_same_visit(visit)
-            false
-          end
-          get :new, state: encrypted_visit
-          expect(response).to be_success
-          expect(response).to render_template('confirmations/new')
-          expect(controller.booked_visit.prison_name).not_to eq(prison_name)
-        end
-      end
-
       it "bails out if the state is not present" do
         get :new
         expect(response.status).to eq(400)


### PR DESCRIPTION
These prison names were last changed in 2014, and we've checked the metrics and verified that these fixes are no longer used.

Whilst we may need to handle prison name changes in the future, we will do this in a better way than by dumping a hash of strings directly into the controller.