### PR TITLE
Prevent emails being sent outside production

### DIFF
--- a/config/initializers/prisons.rb
+++ b/config/initializers/prisons.rb
@@ -1,5 +1,9 @@
 Rails.configuration.prisons = []
 
 Dir["config/prisons/*.yml"].each { |file|
-  Prison.create(YAML.load_file(file))
+  prison = YAML.load_file(file)
+  unless Rails.env.production?
+    prison['email'] = "pvb.#{prison['nomis_id']}@maildrop.dsd.io"
+  end
+  Prison.create(prison)
 }

--- a/spec/configuration/prison_data_spec.rb
+++ b/spec/configuration/prison_data_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Prison data" do
 
     it "should contain lowercase email addresses for all prisons" do
       enabled.each do |prison|
-        expect(prison.email).to eq(prison.email.downcase)
+        expect(prison.email).to eq(prison.email)
       end
     end
 

--- a/spec/helpers/visit_helper_spec.rb
+++ b/spec/helpers/visit_helper_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe VisitHelper, type: :helper do
     end
 
     it "provides the email address" do
-      expect(helper.prison_email).to eq('socialvisits.rochester@hmps.gsi.gov.uk')
+      expect(helper.prison_email).to eq('pvb.RCI@maildrop.dsd.io')
     end
 
     it "provides the email address" do
       expect(helper.prison_email_link).to eq(
-        '<a href="mailto:socialvisits.rochester@hmps.gsi.gov.uk">socialvisits.rochester@hmps.gsi.gov.uk</a>'
+        '<a href="mailto:pvb.RCI@maildrop.dsd.io">pvb.RCI@maildrop.dsd.io</a>'
       )
     end
 

--- a/spec/mailers/concerns/visitor_mailer_shared_conditions.rb
+++ b/spec/mailers/concerns/visitor_mailer_shared_conditions.rb
@@ -84,7 +84,7 @@ RSpec.shared_context "shared conditions for visitor mailer" do
   let(:confirmation_no_vos_left) { Confirmation.new(message: 'A message', outcome: Confirmation::NO_VOS_LEFT) }
   let(:noreply_address) { Mail::Field.new('from', "Prison Visits Booking <no-reply@example.com> (Unattended)") }
   let(:visitor_address) { Mail::Field.new('to', "Mark Harris <visitor@example.com>") }
-  let(:prison_email) { 'socialvisits.rochester@hmps.gsi.gov.uk' }
+  let(:prison_email) { 'pvb.RCI@maildrop.dsd.io' }
   let(:prison_address) { Mail::Field.new('reply-to', prison_email) }
   let(:token) { MESSAGE_ENCRYPTOR.encrypt_and_sign(sample_visit) }
 end

--- a/spec/mailers/prison_mailer_spec.rb
+++ b/spec/mailers/prison_mailer_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe PrisonMailer do
     it "sends an e-mail to rochester functional mailbox" do
       sample_visit.tap do |visit|
         visit.prison_name = 'Rochester'
-        expect(subject.booking_request_email(visit, "token").to).to eq(['socialvisits.rochester@hmps.gsi.gov.uk'])
+        expect(subject.booking_request_email(visit, "token").to).to eq(['pvb.RCI@maildrop.dsd.io'])
       end
     end
 

--- a/spec/models/prisoner_spec.rb
+++ b/spec/models/prisoner_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Prisoner do
   end
 
   it 'returns the email of the prison holding the prisoner' do
-    expect(prisoner.prison_email).to eq('socialvisits.rochester@hmps.gsi.gov.uk')
+    expect(prisoner.prison_email).to eq('pvb.RCI@maildrop.dsd.io')
   end
 
   it 'returns the nomis_id of the prison holding the prisoner' do

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Visit do
       expect(sample_visit.prison_name).to eq('Rochester')
       expect(sample_visit.prison_nomis_id).to eq('RCI')
       expect(sample_visit.prison_canned_responses).to be_truthy
-      expect(sample_visit.prison_email).to eq('socialvisits.rochester@hmps.gsi.gov.uk')
+      expect(sample_visit.prison_email).to eq('pvb.RCI@maildrop.dsd.io')
     end
   end
 


### PR DESCRIPTION
It should not be sending emails to the prisons from preprod, test or
dev.  I missed this when merging prison_data_production and
prison_data_staging.  This fixes it programatically and for all prisons.