### PR TITLE
Do not show disabled prisons in metrics

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,8 +1,8 @@
 class MetricsController < ApplicationController
   permit_only_trusted_users
+  before_action :nomis_ids, only: [:index, :weekly]
 
   def index
-    @nomis_ids = Prison.nomis_ids
     if params[:range] == 'all'
       @dataset = CalculatedMetrics.new(VisitMetricsEntry.deferred, 3.days)
     else
@@ -66,7 +66,6 @@ class MetricsController < ApplicationController
       @start_of_year,
       ApplicationHelper.instance_method(:prison_estate_name_for_id)).
     refresh
-    @nomis_ids = Prison.nomis_ids
 
     respond_to do |format|
       format.html
@@ -74,6 +73,10 @@ class MetricsController < ApplicationController
         render text: @dataset.csv
       end
     end
+  end
+
+  def nomis_ids
+    @nomis_ids = Prison.enabled_nomis_ids
   end
 
   def fortnightly_range

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -61,6 +61,10 @@ class Prison
     all.map(&:nomis_id).compact.sort
   end
 
+  def self.enabled_nomis_ids
+    enabled.map(&:nomis_id).compact.sort
+  end
+
   def anomalous_dates
     (slot_anomalies || {}).keys.to_set
   end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -51,179 +51,182 @@ RSpec.describe Prison, type: :model do
         end
       end
 
-      describe '.enabled' do
-        it 'returns only enabled prisons' do
-          expect(described_class.enabled.all?(&:enabled?)).to be_truthy
+      context 'collections' do
+        let(:enabled)  { object_double(described_class.new, nomis_id: 'ENA', name: 'Enabled', enabled: true) }
+        let(:disabled) { object_double(described_class.new, nomis_id: 'DIS', name: 'Disabled', enabled: false) }
+        let(:no_nomis) { object_double(described_class.new, nomis_id: nil, name: 'No Nomis', enabled: false) }
+
+        let(:prisons) {[enabled, disabled, no_nomis]}
+        before do; allow(Rails.configuration).to receive(:prisons).and_return(prisons) end
+
+        describe '.enabled' do
+          it 'returns only enabled prisons' do
+            expect(described_class.enabled).to match_array([enabled])
+          end
+
+          it 'does not return disabled prisons' do
+            expect(described_class.enabled).not_to include(disabled, no_nomis)
+          end
         end
 
-        it 'does not return disabled prisons' do
-          expect(described_class.enabled).not_to include(disabled_prison)
+        describe '.all' do
+          it 'returns all prisons' do
+            expect(described_class.all).to match_array(prisons)
+          end
         end
-      end
-    end
 
-    describe '.all' do
-      subject { described_class.all }
-      it 'returns all prisons' do
-        expect(subject).to be_kind_of(Array)
-        expect(subject.size).to be >= 1
-        expect(subject.all?{ |p| p.class == described_class}).to be_truthy
-      end
-    end
-
-    describe '.names' do
-      before do
-        allow(described_class).to receive(:all).
-          and_return([double('prison', name: 'Wormwood Scrubs')])
-      end
-      it 'returns all names' do
-        expect(described_class.names).to match_array(['Wormwood Scrubs'])
-      end
-    end
-
-    describe '.nomis_ids' do
-      before do
-        allow(described_class).to receive(:all).
-          and_return([double('prison', nomis_id: 'WSI').as_null_object,
-                      double('prison', nomis_id: nil).as_null_object])
-      end
-      it 'returns nomis ids for all prisons with a nomis id' do
-        expect(described_class.nomis_ids).to match_array(['WSI'])
-      end
-    end
-  end
-
-  context 'instance methods' do
-    subject { complete_prison }
-
-    describe '#name' do
-      it { expect(subject.name).to eq 'Advanced Prison' }
-    end
-
-    describe '#adult_age' do
-      it { expect(subject.adult_age).to eq 18 }
-    end
-
-    describe '#enabled?' do
-      it { expect(subject.enabled?).to be_truthy }
-    end
-
-    describe '#estate' do
-      it { expect(subject.estate).to eq 'Advanced' }
-    end
-
-    describe '#unbookable_dates' do
-      context 'when a prison has unbookable dates' do
-        let(:expected_dates) { Set.new [Date.new(2015, 7, 29), Date.new(2015, 12, 25)] }
-
-        it 'returns a set containing the dates' do
-          expect(subject.unbookable_dates).to eq expected_dates
+        describe '.names' do
+          it 'returns all names' do
+            expect(described_class.names).to match_array(['Enabled', 'Disabled', 'No Nomis'])
+          end
         end
-      end
 
-      context 'when a prison does not have unbookable dates' do
-        subject { basic_prison }
-        it 'returns an empty set' do
-          expect(subject.unbookable_dates).to be_empty
-          expect(subject.unbookable_dates).to be_kind_of Set
+        describe '.nomis_ids' do
+          it 'returns nomis ids for all prisons with a nomis id' do
+            expect(described_class.nomis_ids).to match_array(['DIS', 'ENA'])
+          end
         end
-      end
-    end
 
-    describe '#visiting_slots' do
-      it 'returns the prisons slots as a hash' do
-        expect(subject.visiting_slots).to eq mock_slots_data
-      end
-    end
-
-    describe '#visiting_slot_days' do
-      let(:expected_slot_days_for_everyday_visits) { %w[mon tue wed thu fri sat sun] }
-      let(:weekend_slots_data) {  { "sat" => ["0930-1130"], "sun" => ["1400-1600"] } }
-      let(:expected_slot_days_for_weekend_only_visits) { %w[sat sun] }
-
-      context 'for a prison with everyday visits' do
-        it 'returns the abbreviated day names of available visiting days for the prison' do
-          expect(subject.visiting_slot_days).
-            to eq expected_slot_days_for_everyday_visits
-        end
-      end
-
-      context 'for a prison with weekend only visits' do
-        before do; subject.slots = weekend_slots_data end
-        it 'returns the abbreviated day names of available visiting days for the prison' do
-          expect(subject.visiting_slot_days).
-            to eq expected_slot_days_for_weekend_only_visits
-        end
-      end
-    end
-
-    describe '#anomalous_dates' do
-      context 'when a prison has days for visitation that are different from the regular slots' do
-        subject { complete_prison }
-        let(:expected_anomalous_dates) { Set.new [Date.new(2015, 8, 14)] }
-
-        it 'returns the day' do
-          expect(subject.anomalous_dates).to eq expected_anomalous_dates
-        end
-      end
-
-      context 'when a prison has no anomalous slots' do
-        before do; subject.slot_anomalies = nil end
-
-        it 'returns an empty set' do
-          subject.anomalous_dates.tap do |set|
-            expect(set).to be_empty
-            expect(set).to be_kind_of Set
+        describe '.enabled_nomis_ids' do
+          it 'returns nomis ids for all enabled prisons with a nomis id' do
+            expect(described_class.enabled_nomis_ids).to match_array(['ENA'])
           end
         end
       end
     end
 
-    describe '#days_lead_time' do
-      context 'when a prison has a lead time explicitly set' do
-        it 'returns the value set by the prison config' do
-          expect(subject.days_lead_time).to eq 4
+    context 'instance methods' do
+      subject { complete_prison }
+
+      describe '#name' do
+        it { expect(subject.name).to eq 'Advanced Prison' }
+      end
+
+      describe '#adult_age' do
+        it { expect(subject.adult_age).to eq 18 }
+      end
+
+      describe '#enabled?' do
+        it { expect(subject.enabled?).to be_truthy }
+      end
+
+      describe '#estate' do
+        it { expect(subject.estate).to eq 'Advanced' }
+      end
+
+      describe '#unbookable_dates' do
+        context 'when a prison has unbookable dates' do
+          let(:expected_dates) { Set.new [Date.new(2015, 7, 29), Date.new(2015, 12, 25)] }
+
+          it 'returns a set containing the dates' do
+            expect(subject.unbookable_dates).to eq expected_dates
+          end
+        end
+
+        context 'when a prison does not have unbookable dates' do
+          subject { basic_prison }
+          it 'returns an empty set' do
+            expect(subject.unbookable_dates).to be_empty
+            expect(subject.unbookable_dates).to be_kind_of Set
+          end
         end
       end
 
-      context 'when no lead time has been set' do
-        subject { basic_prison }
-        it 'returns the default value' do
-          expect(subject.days_lead_time).to eq 3
+      describe '#visiting_slots' do
+        it 'returns the prisons slots as a hash' do
+          expect(subject.visiting_slots).to eq mock_slots_data
         end
       end
-    end
 
-    describe '#booking_window' do
-      context 'when a prison has a booking window explicitly set' do
-        it 'returns the value set by the prison config' do
-          expect(subject.booking_window).to eq 14
+      describe '#visiting_slot_days' do
+        let(:expected_slot_days_for_everyday_visits) { %w[mon tue wed thu fri sat sun] }
+        let(:weekend_slots_data) {  { "sat" => ["0930-1130"], "sun" => ["1400-1600"] } }
+        let(:expected_slot_days_for_weekend_only_visits) { %w[sat sun] }
+
+        context 'for a prison with everyday visits' do
+          it 'returns the abbreviated day names of available visiting days for the prison' do
+            expect(subject.visiting_slot_days).
+              to eq expected_slot_days_for_everyday_visits
+          end
+        end
+
+        context 'for a prison with weekend only visits' do
+          before do; subject.slots = weekend_slots_data end
+          it 'returns the abbreviated day names of available visiting days for the prison' do
+            expect(subject.visiting_slot_days).
+              to eq expected_slot_days_for_weekend_only_visits
+          end
         end
       end
-      context 'when no booking window has been set' do
-        subject { basic_prison }
 
-        it 'returns the default value' do
-          expect(subject.booking_window).to eq 28
+      describe '#anomalous_dates' do
+        context 'when a prison has days for visitation that are different from the regular slots' do
+          subject { complete_prison }
+          let(:expected_anomalous_dates) { Set.new [Date.new(2015, 8, 14)] }
+
+          it 'returns the day' do
+            expect(subject.anomalous_dates).to eq expected_anomalous_dates
+          end
+        end
+
+        context 'when a prison has no anomalous slots' do
+          before do; subject.slot_anomalies = nil end
+
+          it 'returns an empty set' do
+            subject.anomalous_dates.tap do |set|
+              expect(set).to be_empty
+              expect(set).to be_kind_of Set
+            end
+          end
         end
       end
-    end
 
-    describe '#works_weekends?' do
-      context 'when a prison has a works weekends boolean flag set' do
-        it 'returns that boolean' do
-          expect(subject.works_weekends?).to be true
+      describe '#days_lead_time' do
+        context 'when a prison has a lead time explicitly set' do
+          it 'returns the value set by the prison config' do
+            expect(subject.days_lead_time).to eq 4
+          end
+        end
+
+        context 'when no lead time has been set' do
+          subject { basic_prison }
+          it 'returns the default value' do
+            expect(subject.days_lead_time).to eq 3
+          end
         end
       end
-      context 'when no works weekends boolean flag has been set' do
-        subject { basic_prison }
-        specify { expect(subject.works_weekends?).to be false }
-      end
-    end
 
-    describe '#works_everyday?' do
-      it 'acts as an alias for .works_weekends?' do
-        expect(subject.method(:works_everyday?)).to eq subject.method(:works_weekends?)
+      describe '#booking_window' do
+        context 'when a prison has a booking window explicitly set' do
+          it 'returns the value set by the prison config' do
+            expect(subject.booking_window).to eq 14
+          end
+        end
+        context 'when no booking window has been set' do
+          subject { basic_prison }
+
+          it 'returns the default value' do
+            expect(subject.booking_window).to eq 28
+          end
+        end
+      end
+
+      describe '#works_weekends?' do
+        context 'when a prison has a works weekends boolean flag set' do
+          it 'returns that boolean' do
+            expect(subject.works_weekends?).to be true
+          end
+        end
+        context 'when no works weekends boolean flag has been set' do
+          subject { basic_prison }
+          specify { expect(subject.works_weekends?).to be false }
+        end
+      end
+
+      describe '#works_everyday?' do
+        it 'acts as an alias for .works_weekends?' do
+          expect(subject.method(:works_everyday?)).to eq subject.method(:works_weekends?)
+        end
       end
     end
   end


### PR DESCRIPTION
The metrics_controller was using Prison.nomis_ids, which exposed the
nomis_ids for all prisons, not simply the enabled ones. I believe this
was causing some cruft to appear in /metrics.  This should fix that.