### PR TITLE
Add estate to every prison

### DIFF
--- a/app/controllers/geckoboard_controller.rb
+++ b/app/controllers/geckoboard_controller.rb
@@ -30,7 +30,7 @@ class GeckoboardController < ApplicationController
   def leaderboard_report
     LeaderboardReport.new(
       0.95,
-      ApplicationHelper.instance_method(:prison_name_for_id)
+      ApplicationHelper.instance_method(:prison_estate_name_for_id)
     )
   end
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -17,7 +17,7 @@ class MetricsController < ApplicationController
       format.csv do
         render text: CSVFormatter.new(
           @nomis_ids,
-          ApplicationHelper.instance_method(:prison_name_for_id)
+          ApplicationHelper.instance_method(:prison_estate_name_for_id)
         ).generate(@dataset)
       end
     end
@@ -64,7 +64,7 @@ class MetricsController < ApplicationController
       VisitMetricsEntry.deferred,
       year,
       @start_of_year,
-      ApplicationHelper.instance_method(:prison_name_for_id)).
+      ApplicationHelper.instance_method(:prison_estate_name_for_id)).
     refresh
     @nomis_ids = Prison.nomis_ids
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,9 +55,9 @@ module ApplicationHelper
     end
   end
 
-  def prison_name_for_id(nomis_id)
+  def prison_estate_name_for_id(nomis_id)
     prison = Prison.find_by_nomis_id(nomis_id)
-    return prison.name if prison && prison.enabled?
+    return prison.estate if prison && prison.enabled?
   end
 
   def markdown(source)

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -15,6 +15,7 @@ class Prison
   attribute :canned_responses, Boolean
   attribute :email, String
   attribute :enabled, Boolean
+  attribute :estate, String
   attribute :finder_slug, String
   attribute :lead_days, Integer,
     default: DEFAULT_LEAD_DAYS,

--- a/app/views/metrics/_all_prisons.html.haml
+++ b/app/views/metrics/_all_prisons.html.haml
@@ -26,7 +26,7 @@
     - @nomis_ids.each do |nomis_id|
       %tr{class: cycle('odd', 'even')}
         %td.prison-name
-          = link_to(prison_name_for_id(nomis_id), prison_metrics_fortnightly_path(nomis_id))
+          = link_to(prison_estate_name_for_id(nomis_id), prison_metrics_fortnightly_path(nomis_id))
         %td.narrow.left-border
           = dataset.total_visits[nomis_id]
         %td.narrow

--- a/app/views/metrics/all_time.html.haml
+++ b/app/views/metrics/all_time.html.haml
@@ -4,7 +4,7 @@
 
 %h1
   Performance indicators for
-  = prison_name_for_id(@nomis_id)
+  = prison_estate_name_for_id(@nomis_id)
   = link_to('(Fortnightly)', prison_metrics_fortnightly_path(@nomis_id))
 %h2
   Summary

--- a/app/views/metrics/fortnightly.html.haml
+++ b/app/views/metrics/fortnightly.html.haml
@@ -4,7 +4,7 @@
 
 %h1
   Fortnightly performance indicators for
-  = prison_name_for_id(@nomis_id)
+  = prison_estate_name_for_id(@nomis_id)
   = link_to('(All time)', prison_metrics_all_time_path(@nomis_id))
   = link_to('Performance over time', prison_metrics_fortnightly_performance_path(@nomis_id))
 %h2

--- a/app/views/metrics/fortnightly_performance.html.haml
+++ b/app/views/metrics/fortnightly_performance.html.haml
@@ -4,7 +4,7 @@
 
 %h1
   Fortnightly performance graph for
-  = prison_name_for_id(@nomis_id)
+  = prison_estate_name_for_id(@nomis_id)
 %h2
   Summary for the year
   - (2014..(Time.zone.today.year)).each do |year|

--- a/app/views/metrics/weekly.html.haml
+++ b/app/views/metrics/weekly.html.haml
@@ -40,7 +40,7 @@
   - @nomis_ids.each do |nomis_id|
     %tr{class: cycle('odd', 'even')}
       %td.prison-name
-        = prison_name_for_id(nomis_id)
+        = prison_estate_name_for_id(nomis_id)
       - @dataset.week_range.each do |week_no|
         %td
           = @dataset.for_nomis_id(nomis_id)[week_no]

--- a/config/prisons/ACI-altcourse.yml
+++ b/config/prisons/ACI-altcourse.yml
@@ -2,3 +2,4 @@
 name: Altcourse
 nomis_id: ACI
 enabled: false
+estate: Altcourse

--- a/config/prisons/AGI-askham-grange.yml
+++ b/config/prisons/AGI-askham-grange.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.askhamgrange@hmps.gsi.gov.uk
 enabled: true
+estate: Askham Grange
 phone: 
 slots:
   sat:

--- a/config/prisons/AKI-acklington.yml
+++ b/config/prisons/AKI-acklington.yml
@@ -2,4 +2,5 @@
 name: Acklington
 nomis_id: AKI
 enabled: false
+estate: Acklington
 finder_slug: acklington2

--- a/config/prisons/ALI-isle-of-wight-albany.yml
+++ b/config/prisons/ALI-isle-of-wight-albany.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisitsisleofwight@hmps.gsi.gov.uk
 enabled: true
+estate: Isle of Wight - Albany
 phone: 01983 634218
 slots:
   fri:

--- a/config/prisons/ASI-ashfield.yml
+++ b/config/prisons/ASI-ashfield.yml
@@ -2,3 +2,4 @@
 name: Ashfield
 nomis_id: ASI
 enabled: false
+estate: Ashfield

--- a/config/prisons/AYI-aylesbury.yml
+++ b/config/prisons/AYI-aylesbury.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.aylesbury@hmps.gsi.gov.uk
 enabled: true
+estate: Aylesbury
 phone: 01296 444099
 slots:
   mon:

--- a/config/prisons/BAI-belmarsh.yml
+++ b/config/prisons/BAI-belmarsh.yml
@@ -10,6 +10,7 @@ booking_window: 21
 canned_responses: true
 email: belmarsh.visits@hmps.gsi.gov.uk
 enabled: true
+estate: Belmarsh
 lead_days: 3
 phone: 0208 3314768
 slots:

--- a/config/prisons/BCI-buckley-hall.yml
+++ b/config/prisons/BCI-buckley-hall.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.buckleyhall@hmps.gsi.gov.uk
 enabled: true
+estate: Buckley Hall
 phone: 01706 514350
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/BFI-bedford.yml
+++ b/config/prisons/BFI-bedford.yml
@@ -8,6 +8,7 @@ booking_window: 14
 canned_responses: true
 email: socialvisits.bedford@hmps.gsi.gov.uk
 enabled: true
+estate: Bedford
 phone: 01234 373196
 slots:
   mon:

--- a/config/prisons/BHI-blantyre-house.yml
+++ b/config/prisons/BHI-blantyre-house.yml
@@ -6,6 +6,7 @@ address:
 - TN17 2NH
 email: socialvisits.blantyrehouse@hmps.gsi.gov.uk
 enabled: false
+estate: Blantyre House
 phone: ''
 reason: it_issues
 slots:

--- a/config/prisons/BLI-bristol.yml
+++ b/config/prisons/BLI-bristol.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisits.bristol@hmps.gsi.gov.uk
 enabled: true
+estate: Bristol
 phone: 0117 372 3213
 slots:
   mon:

--- a/config/prisons/BMI-birmingham.yml
+++ b/config/prisons/BMI-birmingham.yml
@@ -2,3 +2,4 @@
 name: Birmingham
 nomis_id: BMI
 enabled: false
+estate: Birmingham

--- a/config/prisons/BNI-bullingdon-convicted-only.yml
+++ b/config/prisons/BNI-bullingdon-convicted-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.bullingdon@hmps.gsi.gov.uk
 enabled: true
+estate: Bullingdon
 finder_slug: bullingdon
 phone: 01869 353176
 slots:

--- a/config/prisons/BNI-bullingdon-remand-only.yml
+++ b/config/prisons/BNI-bullingdon-remand-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.bullingdon@hmps.gsi.gov.uk
 enabled: true
+estate: Bullingdon
 finder_slug: bullingdon
 phone: 01869 353176
 slots:

--- a/config/prisons/BRI-bure.yml
+++ b/config/prisons/BRI-bure.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.bure@hmps.gsi.gov.uk
 enabled: true
+estate: Bure
 phone: 01603 326252
 slots:
   fri:

--- a/config/prisons/BSI-brinsford.yml
+++ b/config/prisons/BSI-brinsford.yml
@@ -10,6 +10,7 @@ adult_age: 10
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Brinsford
 phone: 0300 060 6500
 slot_anomalies:
   2015-02-23:

--- a/config/prisons/BXI-brixton.yml
+++ b/config/prisons/BXI-brixton.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.brixton@hmps.gsi.gov.uk
 enabled: true
+estate: Brixton
 phone: 0208 678 1433
 slot_anomalies:
   2014-08-12:

--- a/config/prisons/BZI-bronzefield.yml
+++ b/config/prisons/BZI-bronzefield.yml
@@ -2,3 +2,4 @@
 name: Bronzefield
 nomis_id: BZI
 enabled: false
+estate: Bronzefield

--- a/config/prisons/CDI-chelmsford.yml
+++ b/config/prisons/CDI-chelmsford.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.chelmsford@hmps.gsi.gov.uk
 enabled: true
+estate: Chelmsford
 phone: 01245 552265
 slots:
   mon:

--- a/config/prisons/CFI-cardiff.yml
+++ b/config/prisons/CFI-cardiff.yml
@@ -9,6 +9,7 @@ booking_window: 14
 canned_responses: true
 email: socialvisits.cardiff@hmps.gsi.gov.uk
 enabled: true
+estate: Cardiff
 phone: 029 20923327
 slot_anomalies:
   2014-04-21:

--- a/config/prisons/CKI-cookham-wood.yml
+++ b/config/prisons/CKI-cookham-wood.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.cookhamwood@hmps.gsi.gov.uk
 enabled: true
+estate: Cookham Wood
 phone: 01634 202557
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/CLI-coldingley.yml
+++ b/config/prisons/CLI-coldingley.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.coldingley@hmps.gsi.gov.uk
 enabled: true
+estate: Coldingley
 phone: 01483 344418
 slot_anomalies:
   2014-12-23:

--- a/config/prisons/CWI-channings-wood.yml
+++ b/config/prisons/CWI-channings-wood.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisits.channingswood@hmps.gsi.gov.uk
 enabled: true
+estate: Channings Wood
 phone: 01803 812060
 slots:
   wed:

--- a/config/prisons/DAI-dartmoor.yml
+++ b/config/prisons/DAI-dartmoor.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socvisdartmoor@hmps.gsi.gov.uk
 enabled: true
+estate: Dartmoor
 lead_days: 4
 phone: 01822 322022
 slots:

--- a/config/prisons/DHI-drake-hall.yml
+++ b/config/prisons/DHI-drake-hall.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Drake Hall
 phone: 0300 060 6501
 slots:
   tue:

--- a/config/prisons/DMI-durham.yml
+++ b/config/prisons/DMI-durham.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisits.durham@hmps.gsi.gov.uk
 enabled: true
+estate: Durham
 phone: 0191 3323417
 slots:
   mon:

--- a/config/prisons/DNI-doncaster.yml
+++ b/config/prisons/DNI-doncaster.yml
@@ -2,3 +2,4 @@
 name: Doncaster
 nomis_id: DNI
 enabled: false
+estate: Doncaster

--- a/config/prisons/DTI-deerbolt.yml
+++ b/config/prisons/DTI-deerbolt.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.deerbolt@hmps.gsi.gov.uk
 enabled: true
+estate: Deerbolt
 phone: 01833 633349
 slot_anomalies:
   2014-12-23:

--- a/config/prisons/DWI-downview.yml
+++ b/config/prisons/DWI-downview.yml
@@ -6,6 +6,7 @@ address:
 - SM2 5PD
 email: socialvisits.downview@hmps.gsi.gov.uk
 enabled: false
+estate: Downview
 phone: 0208 196 6359
 reason: coming_soon
 slots:

--- a/config/prisons/EEI-erlestoke.yml
+++ b/config/prisons/EEI-erlestoke.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: eecmbookavisit@hmps.gsi.gov.uk
 enabled: true
+estate: Erlestoke
 phone: 01380 814264
 slot_anomalies:
   2015-04-01:

--- a/config/prisons/EHI-standford-hill.yml
+++ b/config/prisons/EHI-standford-hill.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.standfordhill@hmps.gsi.gov.uk
 enabled: true
+estate: Standford Hill
 finder_slug: sheppey-cluster-standford-hill
 phone: 0300 060 6603
 slots:

--- a/config/prisons/ESI-east-sutton-park.yml
+++ b/config/prisons/ESI-east-sutton-park.yml
@@ -6,6 +6,7 @@ address:
 - ME17 3DF
 email: socialvisits.eastsuttonpark@hmps.gsi.gov.uk
 enabled: false
+estate: East Sutton Park
 phone: ''
 reason: coming_soon
 slots:

--- a/config/prisons/EVI-everthorpe.yml
+++ b/config/prisons/EVI-everthorpe.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.everthorpe@hmps.gsi.gov.uk
 enabled: true
+estate: Everthorpe
 phone: 01430 426505
 slots:
   fri:

--- a/config/prisons/EWI-eastwood-park.yml
+++ b/config/prisons/EWI-eastwood-park.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.eastwoodpark@hmps.gsi.gov.uk
 enabled: true
+estate: Eastwood Park
 phone: 01454 382159
 slots:
   tue:

--- a/config/prisons/EXI-exeter.yml
+++ b/config/prisons/EXI-exeter.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.exeter@hmps.gsi.gov.uk
 enabled: true
+estate: Exeter
 phone: 01392 41 5833
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/EYI-elmley.yml
+++ b/config/prisons/EYI-elmley.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.elmley@hmps.gsi.gov.uk
 enabled: true
+estate: Elmley
 finder_slug: sheppey-cluster-elmley
 phone: 0300 060 6605
 slots:

--- a/config/prisons/FBI-forest-bank.yml
+++ b/config/prisons/FBI-forest-bank.yml
@@ -2,3 +2,4 @@
 name: Forest Bank
 nomis_id: FBI
 enabled: false
+estate: Forest Bank

--- a/config/prisons/FDI-ford.yml
+++ b/config/prisons/FDI-ford.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.ford@hmps.gsi.gov.uk
 enabled: true
+estate: Ford
 phone: 
 slots:
   wed:

--- a/config/prisons/FHI-foston-hall.yml
+++ b/config/prisons/FHI-foston-hall.yml
@@ -8,6 +8,7 @@ address:
 - DE65 5DN
 email: socialvisits.fostonhall@hmps.gsi.gov.uk
 enabled: true
+estate: Foston Hall
 phone: 01283 584357
 slots:
   mon:

--- a/config/prisons/FKI-frankland.yml
+++ b/config/prisons/FKI-frankland.yml
@@ -2,3 +2,4 @@
 name: Frankland
 nomis_id: FKI
 enabled: false
+estate: Frankland

--- a/config/prisons/FMI-feltham-young-adults-18-21-only.yml
+++ b/config/prisons/FMI-feltham-young-adults-18-21-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.feltham@hmps.gsi.gov.uk
 enabled: true
+estate: Feltham
 finder_slug: feltham
 phone: 0208 844 5400
 slots:

--- a/config/prisons/FMI-feltham-young-people-15-18-only.yml
+++ b/config/prisons/FMI-feltham-young-people-15-18-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.feltham@hmps.gsi.gov.uk
 enabled: true
+estate: Feltham
 finder_slug: feltham
 phone: 0208 844 5400
 slots:

--- a/config/prisons/FNI-full-sutton.yml
+++ b/config/prisons/FNI-full-sutton.yml
@@ -2,3 +2,4 @@
 name: Full Sutton
 nomis_id: FNI
 enabled: false
+estate: Full Sutton

--- a/config/prisons/FSI-featherstone.yml
+++ b/config/prisons/FSI-featherstone.yml
@@ -9,6 +9,7 @@ address:
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Featherstone
 phone: 0300 060 6502
 slots:
   mon:

--- a/config/prisons/GHI-garth.yml
+++ b/config/prisons/GHI-garth.yml
@@ -2,3 +2,4 @@
 name: Garth
 nomis_id: GHI
 enabled: false
+estate: Garth

--- a/config/prisons/GMI-guys-marsh.yml
+++ b/config/prisons/GMI-guys-marsh.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisitsguysmarsh@hmps.gsi.gov.uk
 enabled: true
+estate: Guys Marsh
 phone: 01747 856586
 slot_anomalies:
   2014-12-29:

--- a/config/prisons/GNI-grendon.yml
+++ b/config/prisons/GNI-grendon.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.grendon@hmps.gsi.gov.uk
 enabled: true
+estate: Grendon
 phone: ''
 slots:
   sat:

--- a/config/prisons/GPI-glen-parva.yml
+++ b/config/prisons/GPI-glen-parva.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.glenparva@hmps.gsi.gov.uk
 enabled: true
+estate: Glen Parva
 phone: 0116 228 4366
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/GTI-gartree.yml
+++ b/config/prisons/GTI-gartree.yml
@@ -9,6 +9,7 @@ address:
 canned_responses: true
 email: socialvisits.gartree@hmps.gsi.gov.uk
 enabled: true
+estate: Gartree
 phone: 01858 426 727
 slots:
   tue:

--- a/config/prisons/HBI-hollesley-bay-open.yml
+++ b/config/prisons/HBI-hollesley-bay-open.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.hollesleybay@hmps.gsi.gov.uk
 enabled: true
+estate: Hollesley Bay Open
 phone: ''
 slots:
   sat:

--- a/config/prisons/HCI-huntercombe.yml
+++ b/config/prisons/HCI-huntercombe.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.huntercombe@hmps.gsi.gov.uk
 enabled: true
+estate: Huntercombe
 phone: 01491 643151
 slot_anomalies:
   2014-12-22:

--- a/config/prisons/HDI-hatfield-open.yml
+++ b/config/prisons/HDI-hatfield-open.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisitshatfield@hmps.gsi.gov.uk
 enabled: true
+estate: Hatfield Open
 finder_slug: hatfield
 phone: 01405 746611
 slot_anomalies:

--- a/config/prisons/HEI-hewell.yml
+++ b/config/prisons/HEI-hewell.yml
@@ -10,6 +10,7 @@ adult_age: 10
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Hewell
 phone: 0300 060 6503
 slots:
   mon:

--- a/config/prisons/HHI-holme-house.yml
+++ b/config/prisons/HHI-holme-house.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.holmehouse@hmps.gsi.gov.uk
 enabled: true
+estate: Holme House
 phone: 03000 606602
 slots:
   fri:

--- a/config/prisons/HII-hindley.yml
+++ b/config/prisons/HII-hindley.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.hindley@hmps.gsi.gov.uk
 enabled: true
+estate: Hindley
 finder_slug: hindley
 phone: 01942 663492
 slots:

--- a/config/prisons/HLI-hull.yml
+++ b/config/prisons/HLI-hull.yml
@@ -6,6 +6,7 @@ address:
 - 'HU9 5LS '
 email: socialvisits.hull@hmps.gsi.gov.uk
 enabled: false
+estate: Hull
 phone: 01482 282016
 reason: coming_soon
 slots:

--- a/config/prisons/HOI-high-down.yml
+++ b/config/prisons/HOI-high-down.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.highdown@hmps.gsi.gov.uk
 enabled: true
+estate: High Down
 phone: 020 7147 6570
 slots:
   sat:

--- a/config/prisons/HPI-highpoint-north.yml
+++ b/config/prisons/HPI-highpoint-north.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.highpoint@hmps.gsi.gov.uk
 enabled: true
+estate: Highpoint
 phone: 01440 743134
 slot_anomalies:
   2014-12-22:

--- a/config/prisons/HPI-highpoint-south.yml
+++ b/config/prisons/HPI-highpoint-south.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.highpoint@hmps.gsi.gov.uk
 enabled: true
+estate: Highpoint
 phone: 01440 743134
 slot_anomalies:
   2015-08-31:

--- a/config/prisons/HVI-haverigg.yml
+++ b/config/prisons/HVI-haverigg.yml
@@ -8,6 +8,7 @@ adult_age: 10
 canned_responses: true
 email: socialvisits.haverigg@hmps.gsi.gov.uk
 enabled: true
+estate: Haverigg
 phone: 01229713016
 slots:
   fri:

--- a/config/prisons/HYI-holloway.yml
+++ b/config/prisons/HYI-holloway.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisits.holloway@hmps.gsi.gov.uk
 enabled: true
+estate: Holloway
 phone: 020 7979 4751
 slot_anomalies:
   2014-05-21:

--- a/config/prisons/ISI-isis.yml
+++ b/config/prisons/ISI-isis.yml
@@ -2,3 +2,4 @@
 name: Isis
 nomis_id: ISI
 enabled: false
+estate: Isis

--- a/config/prisons/IWI-isle-of-wight-parkhurst.yml
+++ b/config/prisons/IWI-isle-of-wight-parkhurst.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisitsisleofwight@hmps.gsi.gov.uk
 enabled: true
+estate: Isle of Wight - Parkhurst
 phone: 01983 634218
 slots:
   fri:

--- a/config/prisons/KMI-kirkham.yml
+++ b/config/prisons/KMI-kirkham.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisits.kirkham@hmps.gsi.gov.uk
 enabled: true
+estate: Kirkham
 phone: 
 slots:
   fri:

--- a/config/prisons/KTI-kennet.yml
+++ b/config/prisons/KTI-kennet.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.kennet@hmps.gsi.gov.uk
 enabled: true
+estate: Kennet
 phone: 0151 213 3179
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/KVI-kirklevington-grange.yml
+++ b/config/prisons/KVI-kirklevington-grange.yml
@@ -2,4 +2,5 @@
 name: Kirklevington Grange
 nomis_id: KVI
 enabled: false
+estate: Kirklevington Grange
 reason: coming_soon

--- a/config/prisons/LCI-leicester.yml
+++ b/config/prisons/LCI-leicester.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisitsleiceste@hmps.gsi.gov.uk
 enabled: true
+estate: Leicester
 phone: 0116 228 3128
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/LEI-leeds.yml
+++ b/config/prisons/LEI-leeds.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.leeds@hmps.gsi.gov.uk
 enabled: true
+estate: Leeds
 phone: 0113 203 2995
 slots:
   fri:

--- a/config/prisons/LFI-lancaster-farms.yml
+++ b/config/prisons/LFI-lancaster-farms.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: lancasterfarmsdomesticvisitsbooking@hmps.gsi.gov.uk
 enabled: true
+estate: Lancaster Farms
 phone: 01524 563636
 slots:
   sat:

--- a/config/prisons/LGI-lowdham-grange.yml
+++ b/config/prisons/LGI-lowdham-grange.yml
@@ -2,3 +2,4 @@
 name: Lowdham Grange
 nomis_id: LGI
 enabled: false
+estate: Lowdham Grange

--- a/config/prisons/LHI-lindholme.yml
+++ b/config/prisons/LHI-lindholme.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.lindholme@hmps.gsi.gov.uk
 enabled: true
+estate: Lindholme
 phone: 01302 524980
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/LII-lincoln.yml
+++ b/config/prisons/LII-lincoln.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: lincolnsocialvisits@hmps.gsi.gov.uk
 enabled: true
+estate: Lincoln
 phone: 01522 663172
 slots:
   sat:

--- a/config/prisons/LLI-long-lartin.yml
+++ b/config/prisons/LLI-long-lartin.yml
@@ -2,3 +2,4 @@
 name: Long Lartin
 nomis_id: LLI
 enabled: false
+estate: Long Lartin

--- a/config/prisons/LNI-low-newton.yml
+++ b/config/prisons/LNI-low-newton.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.lownewton@hmps.gsi.gov.uk
 enabled: true
+estate: Low Newton
 phone: 0191 376 4147
 slots:
   fri:

--- a/config/prisons/LPI-liverpool-closed-only.yml
+++ b/config/prisons/LPI-liverpool-closed-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.liverpool@hmps.gsi.gov.uk
 enabled: true
+estate: Liverpool
 finder_slug: liverpool
 phone: 0151 530 4050
 slots:

--- a/config/prisons/LPI-liverpool-social-visits.yml
+++ b/config/prisons/LPI-liverpool-social-visits.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.liverpool@hmps.gsi.gov.uk
 enabled: true
+estate: Liverpool
 finder_slug: liverpool
 phone: 0151 530 4050
 slots:

--- a/config/prisons/LTI-littlehey.yml
+++ b/config/prisons/LTI-littlehey.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.littlehey@hmps.gsi.gov.uk
 enabled: true
+estate: Littlehey
 lead_days: 2
 phone: 01480 335650
 slots:

--- a/config/prisons/LWI-lewes.yml
+++ b/config/prisons/LWI-lewes.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.lewes@hmps.gsi.gov.uk
 enabled: true
+estate: Lewes
 phone: 01273785277
 slots:
   mon:

--- a/config/prisons/LYI-leyhill.yml
+++ b/config/prisons/LYI-leyhill.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.leyhill@hmps.gsi.gov.uk
 enabled: true
+estate: Leyhill
 phone: 01454 264211
 slots:
   tue:

--- a/config/prisons/MDI-moorland-closed.yml
+++ b/config/prisons/MDI-moorland-closed.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.moorlandclosed@hmps.gsi.gov.uk
 enabled: true
+estate: Moorland Closed
 finder_slug: moorland
 lead_days: 1
 phone: 01302523289

--- a/config/prisons/MHI-morton-hall.yml
+++ b/config/prisons/MHI-morton-hall.yml
@@ -2,3 +2,4 @@
 name: Morton Hall
 nomis_id: MHI
 enabled: false
+estate: Morton Hall

--- a/config/prisons/MRI-manchester.yml
+++ b/config/prisons/MRI-manchester.yml
@@ -2,3 +2,4 @@
 name: Manchester
 nomis_id: MRI
 enabled: false
+estate: Manchester

--- a/config/prisons/MSI-maidstone.yml
+++ b/config/prisons/MSI-maidstone.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.maidstone@hmps.gsi.gov.uk
 enabled: true
+estate: Maidstone
 phone: 01622 775619
 slots:
   tue:

--- a/config/prisons/MTI-the-mount.yml
+++ b/config/prisons/MTI-the-mount.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.themount@hmps.gsi.gov.uk
 enabled: true
+estate: The Mount
 phone: 01442 836352
 slot_anomalies:
   2014-12-23:

--- a/config/prisons/NHI-new-hall.yml
+++ b/config/prisons/NHI-new-hall.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.newhall@hmps.gsi.gov.uk
 enabled: true
+estate: New Hall
 phone: 01924 803219
 slots:
   sat:

--- a/config/prisons/NLI-northumberland.yml
+++ b/config/prisons/NLI-northumberland.yml
@@ -2,3 +2,4 @@
 name: Northumberland
 nomis_id: NLI
 enabled: false
+estate: Northumberland

--- a/config/prisons/NMI-nottingham.yml
+++ b/config/prisons/NMI-nottingham.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.nottingham@hmps.gsi.gov.uk
 enabled: true
+estate: Nottingham
 phone: 0115 962 8980
 slots:
   fri:

--- a/config/prisons/NSI-north-sea-camp.yml
+++ b/config/prisons/NSI-north-sea-camp.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.northseacamp@hmps.gsi.gov.uk
 enabled: true
+estate: North Sea Camp
 phone: 01205 769 368
 slots:
   sat:

--- a/config/prisons/NWI-norwich-a-b-c-e-m-only.yml
+++ b/config/prisons/NWI-norwich-a-b-c-e-m-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.norwich@hmps.gsi.gov.uk
 enabled: true
+estate: Norwich
 finder_slug: norwich
 phone: 01603 708795
 slots:

--- a/config/prisons/NWI-norwich-britannia-house.yml
+++ b/config/prisons/NWI-norwich-britannia-house.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.norwich@hmps.gsi.gov.uk
 enabled: true
+estate: Norwich
 finder_slug: norwich
 phone: 01603 708795
 slots:

--- a/config/prisons/NWI-norwich-f-g-h-l-only.yml
+++ b/config/prisons/NWI-norwich-f-g-h-l-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.norwich@hmps.gsi.gov.uk
 enabled: true
+estate: Norwich
 finder_slug: norwich
 phone: 01603 708795
 slots:

--- a/config/prisons/ONI-onley.yml
+++ b/config/prisons/ONI-onley.yml
@@ -8,6 +8,7 @@ adult_age: 10
 canned_responses: true
 email: socialvisits.onley@hmps.gsi.gov.uk
 enabled: true
+estate: Onley
 phone: 01788 523 402
 slots:
   mon:

--- a/config/prisons/OWI-oakwood.yml
+++ b/config/prisons/OWI-oakwood.yml
@@ -2,4 +2,5 @@
 name: Oakwood
 nomis_id: OWI
 enabled: false
+estate: Oakwood
 finder_slug: hmp-oakwood

--- a/config/prisons/PBI-peterborough.yml
+++ b/config/prisons/PBI-peterborough.yml
@@ -2,3 +2,4 @@
 name: Peterborough
 nomis_id: PBI
 enabled: false
+estate: Peterborough

--- a/config/prisons/PDI-portland.yml
+++ b/config/prisons/PDI-portland.yml
@@ -8,6 +8,7 @@ adult_age: 11
 canned_responses: true
 email: socialvisits.portland@hmps.gsi.gov.uk
 enabled: true
+estate: Portland
 phone: 01305 715775
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/PNI-preston.yml
+++ b/config/prisons/PNI-preston.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.preston@hmps.gsi.gov.uk
 enabled: true
+estate: Preston
 phone: 01772 444666
 slots:
   fri:

--- a/config/prisons/PRI-parc.yml
+++ b/config/prisons/PRI-parc.yml
@@ -2,3 +2,4 @@
 name: Parc
 nomis_id: PRI
 enabled: false
+estate: Parc

--- a/config/prisons/PVI-pentonville.yml
+++ b/config/prisons/PVI-pentonville.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.pentonville@hmps.gsi.gov.uk
 enabled: true
+estate: Pentonville
 phone: 020 70237251
 slots:
   mon:

--- a/config/prisons/RCI-rochester.yml
+++ b/config/prisons/RCI-rochester.yml
@@ -9,6 +9,7 @@ address:
 canned_responses: true
 email: socialvisits.rochester@hmps.gsi.gov.uk
 enabled: true
+estate: Rochester
 phone: 01634 803100
 slots:
   mon:

--- a/config/prisons/RHI-rye-hill.yml
+++ b/config/prisons/RHI-rye-hill.yml
@@ -2,3 +2,4 @@
 name: Rye Hill
 nomis_id: RHI
 enabled: false
+estate: Rye Hill

--- a/config/prisons/RNI-ranby.yml
+++ b/config/prisons/RNI-ranby.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.ranby@hmps.gsi.gov.uk
 enabled: true
+estate: Ranby
 phone: 01777 862107
 slots:
   fri:

--- a/config/prisons/RSI-risley.yml
+++ b/config/prisons/RSI-risley.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.risley@hmps.gsi.gov.uk
 enabled: true
+estate: Risley
 phone: 01925 733284
 slot_anomalies:
   2014-07-25:

--- a/config/prisons/SDI-send.yml
+++ b/config/prisons/SDI-send.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.send@hmps.gsi.gov.uk
 enabled: true
+estate: Send
 phone: 01483 471033
 slot_anomalies:
   2014-12-22:

--- a/config/prisons/SFI-stafford.yml
+++ b/config/prisons/SFI-stafford.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Stafford
 phone: 0300 060 6505
 slot_anomalies:
   2015-10-13:

--- a/config/prisons/SHI-stoke-heath.yml
+++ b/config/prisons/SHI-stoke-heath.yml
@@ -9,6 +9,7 @@ adult_age: 10
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Stoke Heath
 phone: 0300 060 6506
 slots:
   mon:

--- a/config/prisons/SKI-stocken.yml
+++ b/config/prisons/SKI-stocken.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.stocken@hmps.gsi.gov.uk
 enabled: true
+estate: Stocken
 phone: 01780 795156
 slots:
   fri:

--- a/config/prisons/SLI-swaleside.yml
+++ b/config/prisons/SLI-swaleside.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.swaleside@hmps.gsi.gov.uk
 enabled: true
+estate: Swaleside
 phone: 0300 060 6604
 slots:
   mon:

--- a/config/prisons/SNI-swinfen-hall.yml
+++ b/config/prisons/SNI-swinfen-hall.yml
@@ -10,6 +10,7 @@ adult_age: 10
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Swinfen Hall
 phone: 0300 060 6507
 slots:
   tue:

--- a/config/prisons/SPI-spring-hill.yml
+++ b/config/prisons/SPI-spring-hill.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.springhill@hmps.gsi.gov.uk
 enabled: true
+estate: Spring Hill
 phone: 
 slots:
   sat:

--- a/config/prisons/STI-styal.yml
+++ b/config/prisons/STI-styal.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.styal@hmps.gsi.gov.uk
 enabled: true
+estate: Styal
 phone: 01625553195
 slots:
   mon:

--- a/config/prisons/SUI-sudbury.yml
+++ b/config/prisons/SUI-sudbury.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisitssudbury@hmps.gsi.gov.uk
 enabled: true
+estate: Sudbury
 phone: 01283 584066
 slot_anomalies:
   2014-12-22:

--- a/config/prisons/SWI-swansea.yml
+++ b/config/prisons/SWI-swansea.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.swansea@hmps.gsi.gov.uk
 enabled: true
+estate: Swansea
 phone: 01792 48 5322
 slot_anomalies:
   2015-01-01:

--- a/config/prisons/TCI-thorn-cross.yml
+++ b/config/prisons/TCI-thorn-cross.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.thorncross@hmps.gsi.gov.uk
 enabled: true
+estate: Thorn Cross
 phone: 01925805018
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/UKI-usk.yml
+++ b/config/prisons/UKI-usk.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.usk@hmps.gsi.gov.uk
 enabled: true
+estate: Usk
 finder_slug: usk-prescoed-usk
 phone: 01291 671730
 slots:

--- a/config/prisons/UPI-prescoed.yml
+++ b/config/prisons/UPI-prescoed.yml
@@ -2,5 +2,6 @@
 name: Prescoed
 nomis_id: UPI
 enabled: false
+estate: Prescoed
 finder_slug: usk-prescoed-prescoed
 reason: coming_soon

--- a/config/prisons/WCI-winchester-convicted-only.yml
+++ b/config/prisons/WCI-winchester-convicted-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.winchester@hmps.gsi.gov.uk
 enabled: true
+estate: Winchester
 finder_slug: winchester
 phone: 0845 223 5514
 slots:

--- a/config/prisons/WCI-winchester-remand-only.yml
+++ b/config/prisons/WCI-winchester-remand-only.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.winchester@hmps.gsi.gov.uk
 enabled: true
+estate: Winchester
 finder_slug: winchester
 phone: 0845 223 5514
 slots:

--- a/config/prisons/WDI-wakefield.yml
+++ b/config/prisons/WDI-wakefield.yml
@@ -2,3 +2,4 @@
 name: Wakefield
 nomis_id: WDI
 enabled: false
+estate: Wakefield

--- a/config/prisons/WEI-wealstun.yml
+++ b/config/prisons/WEI-wealstun.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.wealstun@hmps.gsi.gov.uk
 enabled: true
+estate: Wealstun
 phone: 01937 444599
 slots:
   mon:

--- a/config/prisons/WHI-woodhill.yml
+++ b/config/prisons/WHI-woodhill.yml
@@ -2,3 +2,4 @@
 name: Woodhill
 nomis_id: WHI
 enabled: false
+estate: Woodhill

--- a/config/prisons/WII-warren-hill.yml
+++ b/config/prisons/WII-warren-hill.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.warrenhill@hmps.gsi.gov.uk
 enabled: true
+estate: Warren Hill
 phone: 020 8588 4002
 slot_anomalies:
   2014-12-24:

--- a/config/prisons/WLI-wayland.yml
+++ b/config/prisons/WLI-wayland.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.wayland@hmps.gsi.gov.uk
 enabled: true
+estate: Wayland
 phone: 001953 804152
 slots:
   tue:

--- a/config/prisons/WMI-wymott.yml
+++ b/config/prisons/WMI-wymott.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.wymott@hmps.gsi.gov.uk
 enabled: true
+estate: Wymott
 phone: 01772 442234
 slot_anomalies:
   2015-08-31:

--- a/config/prisons/WNI-werrington.yml
+++ b/config/prisons/WNI-werrington.yml
@@ -9,6 +9,7 @@ adult_age: 10
 canned_responses: true
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
+estate: Werrington
 phone: 0300 060 6508
 slots:
   wed:

--- a/config/prisons/WOI-wolds.yml
+++ b/config/prisons/WOI-wolds.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.everthorpe@hmps.gsi.gov.uk
 enabled: true
+estate: Wolds
 phone: 01430 426505
 slots:
   fri:

--- a/config/prisons/WRI-whitemoor.yml
+++ b/config/prisons/WRI-whitemoor.yml
@@ -2,3 +2,4 @@
 name: Whitemoor
 nomis_id: WRI
 enabled: false
+estate: Whitemoor

--- a/config/prisons/WSI-wormwood-scrubs.yml
+++ b/config/prisons/WSI-wormwood-scrubs.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.wormwoodscrubs@hmps.gsi.gov.uk
 enabled: true
+estate: Wormwood Scrubs
 phone: 020 8588 3564
 slots:
   mon:

--- a/config/prisons/WTI-whatton.yml
+++ b/config/prisons/WTI-whatton.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.whatton@hmps.gsi.gov.uk
 enabled: true
+estate: Whatton
 phone: 01949 803564
 slots:
   fri:

--- a/config/prisons/WWI-wandsworth.yml
+++ b/config/prisons/WWI-wandsworth.yml
@@ -8,6 +8,7 @@ address:
 canned_responses: true
 email: socialvisits.wandsworth@hmps.gsi.gov.uk
 enabled: true
+estate: Wandsworth
 phone: 0208 588 4002
 slots:
   mon:

--- a/config/prisons/WYI-wetherby.yml
+++ b/config/prisons/WYI-wetherby.yml
@@ -7,6 +7,7 @@ address:
 canned_responses: true
 email: socialvisits.wetherby@hmps.gsi.gov.uk
 enabled: true
+estate: Wetherby
 phone: 01937 544207
 slots:
   wed:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
-  describe '#prison_name_for_id' do
+  describe '#prison_estate_name_for_id' do
     it 'returns a prison name for a nomis id' do
-      expect(helper.prison_name_for_id('RCI')).to eq('Rochester')
+      expect(helper.prison_estate_name_for_id('RCI')).to eq('Rochester')
     end
 
     it 'returns nil for a bad nomis id' do
-      expect(helper.prison_name_for_id('Bad Id')).to be_nil
+      expect(helper.prison_estate_name_for_id('Bad Id')).to be_nil
     end
   end
 

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe Prison, type: :model do
       it { expect(subject.enabled?).to be_truthy }
     end
 
+    describe '#estate' do
+      it { expect(subject.estate).to eq 'Advanced' }
+    end
+
     describe '#unbookable_dates' do
       context 'when a prison has unbookable dates' do
         let(:expected_dates) { Set.new [Date.new(2015, 7, 29), Date.new(2015, 12, 25)] }

--- a/spec/shared_examples_prison_slots_and_data.rb
+++ b/spec/shared_examples_prison_slots_and_data.rb
@@ -31,6 +31,7 @@ RSpec.shared_examples "prison slots and data" do
 
   let(:advanced_attributes) do
     { "name" =>            'Advanced Prison',
+      "estate" =>          'Advanced',
       "nomis_id" =>        'APP',
       "lead_days" =>       4,
       "booking_window" =>  14,


### PR DESCRIPTION
The nomis_id is not unique amoung the different organisational units
that comprise some prisons (Winchester Remand Only and Winchester
Convicted Only, for example). However, it is used for calculating
metrics. This causes errors as it unclear which unit the metric is
related to.  Adding an organisational unit of 'estate' should resolve
this as it will allow the report to show the higher-level organisation
the nomis_id actually appies to ('Winchester' here, for instance).