### PR TITLE
Send to maildrop in test or based on env

### DIFF
--- a/config/initializers/prisons.rb
+++ b/config/initializers/prisons.rb
@@ -2,7 +2,7 @@ Rails.configuration.prisons = []
 
 Dir["config/prisons/*.yml"].each { |file|
   prison = YAML.load_file(file)
-  unless Rails.env.production?
+  if ENV['GSI_SMTP_HOSTNAME'] == 'maildrop.dsd.io' || Rails.env.test?
     prison['email'] = "pvb.#{prison['nomis_id']}@maildrop.dsd.io"
   end
   Prison.create(prison)


### PR DESCRIPTION
This was being selected for everything but production, but preprod, of
course, runs in production mode, so it wasn't working. This fixes that.