### PR TITLE
Move validity check to model and log missing info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'capybara'
   gem 'rspec_junit_formatter'
+  gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'poltergeist'
   gem 'chromedriver-helper'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pg (0.18.2)
+    phantomjs (1.9.8.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -360,6 +361,7 @@ DEPENDENCIES
   moj_template (= 0.21.0)
   parallel
   pg
+  phantomjs
   poltergeist
   prison_staff_info!
   pry-byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Visit::IntegrityChecker
+
   helper_method :visit
   before_action :add_extra_sentry_metadata
   protect_from_forgery with: :exception
@@ -65,16 +67,6 @@ class ApplicationController < ActionController::Base
 
   def metrics_logger
     METRICS_LOGGER
-  end
-
-  def ensure_visit_integrity
-    unless visit && visit.prisoner && visit.prison_name.present?
-      flash[:notice] = I18n.t(
-        :ensure_visit_integrity,
-        scope: 'controllers.shared'
-      )
-      redirect_to edit_prisoner_details_path
-    end
   end
 
   def pad_execution_time(execution_time)

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -40,4 +40,24 @@ class Visit
   def same_visit?(other)
     other.visit_id == self.visit_id
   end
+
+  def prisoner?
+    prisoner.present?
+  end
+
+  def prisoner_number?
+    prisoner? && prisoner.number.present?
+  end
+
+  def prison_name?
+    prisoner? && prisoner.prison_name.present?
+  end
+
+  def prison?
+    prisoner && prison.present?
+  end
+
+  def prison_slots?
+    prison? && prison.slots.present?
+  end
 end

--- a/app/services/visit/integrity_checker.rb
+++ b/app/services/visit/integrity_checker.rb
@@ -1,0 +1,58 @@
+class Visit
+  module IntegrityChecker
+    def ensure_visit_integrity
+      return if required_information?
+      log_any_missing_information
+      flash[:notice] = I18n.t(
+        :ensure_visit_integrity,
+        scope: 'controllers.shared'
+      )
+      redirect_to edit_prisoner_details_path
+    end
+
+    def required_information?
+      visit && visit.prisoner? && visit.prison_name?
+    end
+
+    def log_any_missing_information
+      prefix = "Visit #{visit.visit_id} is missing a"
+      log_missing_prisoner(prefix)
+      log_missing_prisoner_number(prefix)
+      log_missing_prison_name(prefix)
+      log_missing_prison(prefix)
+      log_missing_prison_slots(prefix)
+    end
+
+    private
+
+    def log_missing_prisoner(prefix)
+      unless visit.prisoner?
+        Rails.logger.info("#{prefix} prisoner")
+      end
+    end
+
+    def log_missing_prisoner_number(prefix)
+      if visit.prisoner? && !visit.prisoner_number?
+        Rails.logger.info("#{prefix} prisoner number")
+      end
+    end
+
+    def log_missing_prison_name(prefix)
+      if visit.prison? && !visit.prison_name?
+        Rails.logger.info("#{prefix} prison name")
+      end
+    end
+
+    def log_missing_prison(prefix)
+      if visit.prisoner? && !visit.prison?
+        Rails.logger.info("#{prefix} prison")
+      end
+    end
+
+    def log_missing_prison_slots(prefix)
+      if visit.prison? && !visit.prison_slots?
+        Rails.logger.info("#{prefix} prison with slots")
+      end
+    end
+  end
+end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -1,96 +1,102 @@
 require 'rails_helper'
 
 RSpec.describe Visit do
-  let :adult_visitor do
+  let(:adult_visitor) {
     Visitor.new(date_of_birth: (Time.zone.today - 19.years))
-  end
+  }
 
-  let :child_visitor do
+  let(:child_visitor) {
     Visitor.new(date_of_birth: (Time.zone.today - 10.years))
-  end
+  }
 
-  let :sample_visit do
+  subject {
     Visit.new(visit_id: SecureRandom.hex, prisoner: Prisoner.new(prison_name: 'Rochester'))
-  end
+  }
 
   describe 'delegation' do
+    it { expect(subject.prisoner?).to be_truthy }
+    it { expect(subject.prisoner_number?).to be_falsey }
+    it { expect(subject.prison_name?).to be_truthy }
+    it { expect(subject.prison?).to be_truthy }
+    it { expect(subject.prison_slots?).to be_truthy }
+
     it 'exposes the prison via the prisoner' do
-      expect(sample_visit.prison.to_json).to eq(Prison.find('Rochester').to_json)
+      expect(subject.prison.to_json).to eq(Prison.find('Rochester').to_json)
     end
 
     it 'exposes some prison attributes via the prisoner' do
-      expect(sample_visit.prison_name).to eq('Rochester')
-      expect(sample_visit.prison_nomis_id).to eq('RCI')
-      expect(sample_visit.prison_email).to eq('pvb.RCI@maildrop.dsd.io')
+      expect(subject.prison_name).to eq('Rochester')
+      expect(subject.prison_nomis_id).to eq('RCI')
+      expect(subject.prison_email).to eq('pvb.RCI@maildrop.dsd.io')
     end
   end
 
   it "restricts the number of visitors" do
-    sample_visit.visitors = []
-    expect(sample_visit.valid?(:visitors_set)).to be_falsey
+    subject.visitors = []
+    expect(subject.valid?(:visitors_set)).to be_falsey
 
-    sample_visit.visitors = [child_visitor] * 7
-    expect(sample_visit.valid?(:visitors_set)).to be_falsey
+    subject.visitors = [child_visitor] * 7
+    expect(subject.valid?(:visitors_set)).to be_falsey
 
-    sample_visit.visitors = [adult_visitor] * 1 + [child_visitor] * 5
-    expect(sample_visit.valid?(:visitors_set)).to be_truthy
+    subject.visitors = [adult_visitor] * 1 + [child_visitor] * 5
+    expect(subject.valid?(:visitors_set)).to be_truthy
   end
 
   it "restricts the number of slots" do
-    sample_visit.slots = []
-    sample_visit.visitors = [adult_visitor]
-    expect(sample_visit.valid?(:date_and_time)).to be_falsey
+    subject.slots = []
+    subject.visitors = [adult_visitor]
+    expect(subject.valid?(:date_and_time)).to be_falsey
 
     (1..3).each do |t|
-      sample_visit.slots = [Slot.new] * t
-      expect(sample_visit.valid?(:date_and_time)).to be_truthy
+      subject.slots = [Slot.new] * t
+      expect(subject.valid?(:date_and_time)).to be_truthy
     end
 
-    sample_visit.slots = [Slot.new] * 4
-    expect(sample_visit.valid?(:date_and_time)).to be_falsey
+    subject.slots = [Slot.new] * 4
+    expect(subject.valid?(:date_and_time)).to be_falsey
   end
 
   it 'is valid with three or fewer adult visitors' do
     3.times do
-      sample_visit.visitors << double(age: 19)
+      subject.visitors << double(age: 19)
     end
-    expect(sample_visit.valid?(:visitors_set)).to be_truthy
+    expect(subject.valid?(:visitors_set)).to be_truthy
   end
 
   it 'is invalid with more than three adult visitors' do
     4.times do
-      sample_visit.visitors << double(age: 19)
+      subject.visitors << double(age: 19)
     end
-    expect(sample_visit.valid?(:visitors_set)).to be_falsey
+    expect(subject.valid?(:visitors_set)).to be_falsey
   end
 
   context "a prison which treats a child as an adult for seating purposes" do
     before do
-      sample_visit.prison_name = 'Deerbolt'
-      sample_visit.visitors = []
+      subject.prison_name = 'Deerbolt'
+      subject.visitors = []
     end
 
     let(:group_with_adult) do
       [double(age: 19), double(age: 10),
        double(age: 10), double(age: 9)
-      ].each { |v| sample_visit.visitors << v }
+      ].each { |v| subject.visitors << v }
     end
 
     let(:group_of_children) do
       [double(age: 9), double(age: 10),
        double(age: 10), double(age: 9)
-      ].each { |v| sample_visit.visitors << v }
+      ].each { |v| subject.visitors << v }
     end
 
     it "requires at least one real adult" do
       group_with_adult
-      expect(sample_visit.valid?(:visitors_set)).to be_truthy
+      expect(subject.valid?(:visitors_set)).to be_truthy
     end
 
     it "fails if there is not at least one adult" do
       group_of_children
-      sample_visit.valid?
-      expect(sample_visit.valid?(:visitors_set)).to be_falsey
+      subject.valid?
+      expect(subject.valid?(:visitors_set)).to be_falsey
     end
   end
 
@@ -98,26 +104,26 @@ RSpec.describe Visit do
     Visit.new do |visit|
       expect {
         visit.visit_id = SecureRandom.hex
-      }.to change { visit.valid?(:visit_id) }
+      }.to change { visit.valid?(:visit_id) }.from(false).to(true)
     end
   end
 
   it "knows if a visitor is an adult or not" do
-    expect(sample_visit.adult?(adult_visitor)).to be_truthy
-    expect(sample_visit.adult?(child_visitor)).to be_falsey
+    expect(subject.adult?(adult_visitor)).to be_truthy
+    expect(subject.adult?(child_visitor)).to be_falsey
   end
 
   describe 'same_visit?' do
     it 'is true if two different visits have the same visit_id' do
-      a = sample_visit
-      b = sample_visit.dup
+      a = subject
+      b = subject.dup
       expect(a).not_to eq(b)
       expect(a).to be_same_visit(b)
     end
 
     it 'is false if two different visits have a different visit_id' do
-      a = sample_visit
-      b = sample_visit.dup
+      a = subject
+      b = subject.dup
       b.visit_id = SecureRandom.hex
       expect(a).not_to be_same_visit(b)
     end

--- a/spec/services/visit/integrity_checker_spec.rb
+++ b/spec/services/visit/integrity_checker_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe Visit::IntegrityChecker do
+  before do
+    class VisitTestController
+      include Visit::IntegrityChecker
+
+      def visit
+        Visit.new(visit_id: 12345,
+                  prisoner: Prisoner.new(
+                    prison_name: 'Rochester',
+                    number: 1234))
+      end
+
+      def flash
+        {}
+      end
+
+      def redirect_to(_)
+      end
+
+      def edit_prisoner_details_path
+      end
+    end
+  end
+
+  subject { VisitTestController.new }
+
+  context 'checking' do
+    describe '#ensure_visit_integrity' do
+      context 'fails' do
+        before do
+          allow(subject).to receive(:required_information?).
+            and_return(false)
+        end
+
+        it 'generates an alert' do
+          expect(I18n).to receive(:t).
+            with(:ensure_visit_integrity, scope: "controllers.shared")
+          subject.ensure_visit_integrity
+        end
+
+        it 'redirects' do
+          expect(subject).to receive(:redirect_to)
+          expect(subject).to receive(:edit_prisoner_details_path)
+          subject.ensure_visit_integrity
+        end
+      end
+    end
+  end
+
+  describe '#required_information?' do
+    context 'returns false when a visit' do
+      it 'is missing a prisoner' do
+        allow_any_instance_of(Visit).to receive(:prisoner).and_return(nil)
+        expect(subject.required_information?).to be_falsey
+      end
+
+      it 'has a prisoner without a prison name' do
+        allow_any_instance_of(Prisoner).to receive(:prison_name).and_return(nil)
+        expect(subject.required_information?).to be_falsey
+      end
+    end
+  end
+
+  context 'logging' do
+    describe '#log_any_missing_information' do
+      it 'gets called by #ensure_visit_integrity' do
+        expect(subject).to receive(:log_any_missing_information)
+        expect(subject).to receive(:required_information?).and_return(false)
+        subject.ensure_visit_integrity
+      end
+
+      context 'logs visits' do
+        it 'that are missing a prisoner' do
+          expect(Rails.logger).to receive(:info).with(/missing a prisoner/)
+          allow_any_instance_of(Visit).to receive(:prisoner).and_return(nil)
+          subject.log_any_missing_information
+        end
+
+        it 'that have a prisoner without a prison name' do
+          expect(Rails.logger).to receive(:info).with(/missing a prison name/)
+          allow_any_instance_of(Visit).to receive(:prisoner).
+            and_return(double('prisoner', prison_name: nil, present?: true).as_null_object)
+          subject.log_any_missing_information
+        end
+
+        it 'that are missing a prison' do
+          expect(Rails.logger).to receive(:info).with(/missing a prison$/)
+          allow_any_instance_of(Prisoner).to receive(:prison).and_return(nil)
+          subject.log_any_missing_information
+        end
+
+        it 'that have a prisoner with a missing prisoner number' do
+          expect(Rails.logger).to receive(:info).with(/missing a prisoner number/)
+          allow_any_instance_of(Visit).to receive(:prisoner).
+            and_return(double('prisoner', number: nil, blank?: false).as_null_object)
+          subject.log_any_missing_information
+        end
+
+        it 'that have a prison with no slots' do
+          expect(Rails.logger).to receive(:info).with(/missing a prison with slots/)
+          allow_any_instance_of(Prisoner).to receive(:prison).
+            and_return(object_double(Prison.new, name: 'Rochester', slots: {}))
+          subject.log_any_missing_information
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are experiencing 500 errors on the live service that *appear* to be
happening when existing visits are deserialised. Visits lose their
prisoner_name and prison.slots attributes.  This commit removes the
bulk of the Visit integrity checking logic to the model and uses
that method, `required_information?`, to call a series of logging methods
that look for missing prisoner and prison associations.  Hopefully, this
will give us some insight on where these errors are coming from.