### PR TITLE
Update Wetherby Christmas visit slots

### DIFF
--- a/config/prisons/WYI-wetherby.yml
+++ b/config/prisons/WYI-wetherby.yml
@@ -8,6 +8,15 @@ email: socialvisits.wetherby@hmps.gsi.gov.uk
 enabled: true
 estate: Wetherby
 phone: 01937 544207
+slot_anomalies:
+  2015-12-24:
+  - 1430-1630
+  2015-12-28:
+  - 1430-1630
+  2015-12-31:
+  - 1430-1630
+  2016-01-01:
+  - 1430-1630
 slots:
   wed:
   - 1830-2000
@@ -19,3 +28,4 @@ slots:
   - 1430-1630
 unbookable:
 - 2014-12-25
+- 2015-12-25


### PR DESCRIPTION
Unbookable - Christmas Day
Additional slots - 24th, 28th, 31st Dec and 1st Jan 1430-1630