### PR TITLE
Update Gartree Christmas visit slots

### DIFF
--- a/config/prisons/GTI-gartree.yml
+++ b/config/prisons/GTI-gartree.yml
@@ -10,6 +10,9 @@ email: socialvisits.gartree@hmps.gsi.gov.uk
 enabled: true
 estate: Gartree
 phone: 01858 426 727
+slot_anomalies:
+  2015-12-28:
+  - 1400-1600
 slots:
   tue:
   - 1400-1600
@@ -25,3 +28,6 @@ unbookable:
 - 2014-12-25
 - 2014-12-26
 - 2015-01-01
+- 2015-12-25
+- 2015-12-26
+- 2016-01-01


### PR DESCRIPTION
Unbookable:
- Christmas Day
- Boxing Day
- New Year's Day

Slot anomaly:
- 28th Dec 1400-1600