### PR TITLE
Update Everthorpe (Humber) Christmas visit slots

### DIFF
--- a/config/prisons/EVI-everthorpe.yml
+++ b/config/prisons/EVI-everthorpe.yml
@@ -8,6 +8,10 @@ email: socialvisits.everthorpe@hmps.gsi.gov.uk
 enabled: true
 estate: Everthorpe
 phone: 01430 426505
+slot_anomalies:
+  2015-12-23:
+  - 0930-1130
+  - 1400-1600
 slots:
   fri:
   - 1415-1615
@@ -22,3 +26,4 @@ slots:
   - 1415-1615
 unbookable:
 - 2014-12-25
+- 2015-12-25


### PR DESCRIPTION
Unbookable:
Christmas Day

Additional visits:
- 23rd December 0930-1130 and 1400-1600