### PR TITLE
Update Wayland Christmas visit slots

### DIFF
--- a/config/prisons/WLI-wayland.yml
+++ b/config/prisons/WLI-wayland.yml
@@ -8,6 +8,9 @@ email: socialvisits.wayland@hmps.gsi.gov.uk
 enabled: true
 estate: Wayland
 phone: 01953 804152
+slot_anomalies:
+  2015-12-24:
+  - 1400-1600
 slots:
   tue:
   - 1400-1600
@@ -22,3 +25,7 @@ slots:
 unbookable:
 - 2014-12-25
 - 2015-01-01
+- 2015-12-25
+- 2015-12-26
+- 2015-12-31
+- 2016-01-01


### PR DESCRIPTION
Unbookable:
- Christmas Day
- Boxing Day
- New Year's Eve
- New Year's Day

Slot anomalies:
- 24th Dec 1400-1600