### PR TITLE
Update North Sea Camp Christmas visit slots

### DIFF
--- a/config/prisons/NSI-north-sea-camp.yml
+++ b/config/prisons/NSI-north-sea-camp.yml
@@ -8,6 +8,10 @@ email: socialvisits.northseacamp@hmps.gsi.gov.uk
 enabled: true
 estate: North Sea Camp
 phone: 01205 769 368
+slot_anomalies:
+  2015-12-28:
+  - 0900-1130
+  - 1330-1545
 slots:
   sat:
   - 0900-1130
@@ -19,3 +23,8 @@ slots:
   - 1330-1545
 unbookable:
 - 2014-12-25
+- 2015-12-24
+- 2015-12-25
+- 2015-12-26
+- 2015-12-31
+- 2016-01-01


### PR DESCRIPTION
Unbookable:
- Christmas Eve
- Christmas Day
- Boxing Day
- New Year's Eve
- New Year's Day

Slot anomalies:
- 28th Dec 0900-1130 and 1330-1545