### PR TITLE
Update Leicester Christmas visit slots

### DIFF
--- a/config/prisons/LCI-leicester.yml
+++ b/config/prisons/LCI-leicester.yml
@@ -8,7 +8,13 @@ email: socialvisitsleiceste@hmps.gsi.gov.uk
 enabled: true
 estate: Leicester
 phone: 0116 228 3128
-slot_anomalies: {}
+slot_anomalies:
+  2015-12-24:
+  - 0900-1100
+  - 1415-1615
+  2015-12-31:
+  - 0900-1100
+  - 1415-1615
 slots:
   mon:
   - 1415-1615
@@ -22,4 +28,7 @@ slots:
   - 1415-1615
   sun:
   - 1415-1615
-unbookable: []
+unbookable:
+- 2015-12-25
+- 2015-12-26
+- 2016-01-01


### PR DESCRIPTION
Unbookable
- Christmas Day
- Boxing Day
- New Year's Day

Slot anomalies:
- Christmas Eve 0900-1100 and 1415-1615
- New Year's Eve 0900-1100 and 1415-1615