### PR TITLE
Clarify allowance wording

### DIFF
--- a/app/views/confirmations/_canned_responses.html.haml
+++ b/app/views/confirmations/_canned_responses.html.haml
@@ -102,7 +102,7 @@
             However, you can book a weekday visit with visiting allowance valid until
             = succeed '.' do
               %span.date [DATE NOT CHOSEN]
-            The visit must be taken before the allowance expires.
+            The visit must be booked before the allowance expires.
 
   %h2 Issue with the prisoner
 

--- a/app/views/mailers_common/_booking_rejection.html.haml
+++ b/app/views/mailers_common/_booking_rejection.html.haml
@@ -32,7 +32,7 @@
 
   - if @confirmation.no_pvo
 
-    %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } However, you can book a weekday visit with visiting allowance valid until #{format_date_of_visit(@confirmation.renew_pvo)}. The visit must be taken before the allowance expires.
+    %p{ style: 'margin:1em 0;font: 16px Helvetica, Arial, sans-serif' } However, you can book a weekday visit with visiting allowance valid until #{format_date_of_visit(@confirmation.renew_pvo)}. The visit must be booked before the allowance expires.
 
   - if @confirmation.no_vo
 

--- a/app/views/mailers_common/_booking_rejection.text.erb
+++ b/app/views/mailers_common/_booking_rejection.text.erb
@@ -16,7 +16,7 @@ Please visit www.gov.uk/prison-visits to choose some alternative dates.
 We’re sorry, but the prisoner you want to visit has not got any visiting allowance left for the dates you’ve chosen.
 <% if @confirmation.no_pvo %>
 
-However, you can book a weekday visit with visiting allowance valid until <%= format_date_of_visit(@confirmation.renew_pvo) %>. The visit must be taken before the allowance expires.
+However, you can book a weekday visit with visiting allowance valid until <%= format_date_of_visit(@confirmation.renew_pvo) %>. The visit must be booked before the allowance expires.
 <% end %>
 <% if @confirmation.no_vo %>
 


### PR DESCRIPTION
Problem reported by prison staff:

> We find the wording confusing on the section regarding visiting allowance. If there is still availability to use a PVO, it currently says “However, you can book a weekday visit with visiting allowance valid until ????. The visit must be TAKEN before the allowance expires.”
> 
> We think it would be clearer if it said “must be BOOKED before the allowance expires”.