### PR TITLE
Include custom app directories in code stats

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,0 +1,21 @@
+task(:stats).prerequisites.unshift task('pvb:statsetup')
+
+namespace :pvb do
+  task :statsetup do
+    require 'rails/code_statistics'
+
+    ignored = %w[
+      ./app/assets
+      ./app/views
+    ]
+
+    Dir['./app/*'].each do |path|
+      next unless File.directory?(path)
+      next if ignored.include?(path)
+      next if ::STATS_DIRECTORIES.any? { |_, p| p == path }
+      name = path.split('/').last.capitalize
+
+      ::STATS_DIRECTORIES << [name, path]
+    end
+  end
+end


### PR DESCRIPTION
Rails comes with a predefined list of blessed directories in a big global constant that it uses to calculate statistics in `rake stats`, and will ignore custom directories like `app/validators`, `app/services` etc.

This adds these directories in the same way that RSpec does it.