### PR TITLE
Update Low Newton Christmas visit slots

### DIFF
--- a/config/prisons/LNI-low-newton.yml
+++ b/config/prisons/LNI-low-newton.yml
@@ -8,6 +8,11 @@ email: socialvisits.lownewton@hmps.gsi.gov.uk
 enabled: true
 estate: Low Newton
 phone: 0191 376 4147
+slot_anomalies:
+  2015-12-23:
+  - 1345-1545
+  2015-12-28:
+  - 1345-1545
 slots:
   fri:
   - 1415-1545
@@ -20,6 +25,6 @@ slots:
   tue:
   - 1415-1545
 unbookable:
-- 2014-12-25
-- 2014-12-26
-- 2015-01-01
+- 2015-12-25
+- 2015-12-26
+- 2016-01-01


### PR DESCRIPTION
Slot anomalies:
- 23rd December 1345-1545
- 28th December 1345-1545

Unbookable:
- Christmas Day
- Boxing Day
- New Year's Day