### PR TITLE
Obviate the need for empty YAML defaults

### DIFF
--- a/config/initializers/prisons.rb
+++ b/config/initializers/prisons.rb
@@ -1,7 +1,13 @@
 Rails.configuration.prisons = []
 
+default = {
+  slot_anomalies: {},
+  slots: {},
+  unbookable: []
+}
+
 Dir["config/prisons/*.yml"].each { |file|
-  prison = YAML.load_file(file)
+  prison = default.merge(YAML.load_file(file))
   if ENV['GSI_SMTP_HOSTNAME'] == 'maildrop.dsd.io' || Rails.env.test?
     prison['email'] = "pvb.#{prison['nomis_id']}@maildrop.dsd.io"
   end

--- a/config/prisons/NMI-nottingham.yml
+++ b/config/prisons/NMI-nottingham.yml
@@ -24,4 +24,3 @@ slots:
   tue:
   - 0900-1100
   - 1415-1615
-unbookable: []

--- a/config/prisons/WHI-woodhill.yml
+++ b/config/prisons/WHI-woodhill.yml
@@ -24,4 +24,3 @@ slots:
   - 1400-1600
   sun:
   - 1400-1600
-unbookable: []


### PR DESCRIPTION
By providing sensible defaults, we no longer need to put lines like `unbookable: []` in the YAML.