### PR TITLE
Proxy certain paths to new app (prototype)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'curb'
 gem 'string_scrubber', '>= 0.2.0'
 gem 'virtus'
 gem 'sinatra'
+gem 'rack-proxy'
 
 group :test do
   gem 'codeclimate-test-reporter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    rack-proxy (0.5.17)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.4)
@@ -366,6 +368,7 @@ DEPENDENCIES
   prison_staff_info!
   pry-byebug
   pry-rails
+  rack-proxy
   rails
   redcarpet
   rspec-html-matchers
@@ -392,4 +395,4 @@ DEPENDENCIES
   zendesk_api
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,7 @@ module PrisonVisits2
     config.trusted_users_access_key = ENV['TRUSTED_USERS_ACCESS_KEY']
     config.permitted_ips_for_confirmations =
       (ENV['PRISON_ESTATE_IPS'] || '').split(',')
+    config.new_app_url = ENV['NEW_APP_URL']
 
     config.autoload_paths += %w(lib app/mailers/concerns)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,16 @@ PrisonVisits2::Application.routes.draw do
   # rubocop:disable Metrics/LineLength
   get 'ping' => 'ping#index'
 
+  # Enable proxying to the new application if url configured
+  new_app_url = Rails.application.config.new_app_url
+  if new_app_url
+    new_app = NewAppProxy.new(url: new_app_url, read_timeout: 5)
+
+    %w[/en /cy].each do |prefix|
+      match "#{prefix}/*all", to: new_app, via: :all
+    end
+  end
+
   resource :feedback
 
   resources :frontend_events, only: [:create]

--- a/lib/new_app_proxy.rb
+++ b/lib/new_app_proxy.rb
@@ -1,0 +1,15 @@
+require 'rack-proxy'
+
+class NewAppProxy < Rack::Proxy
+  def initialize(options)
+    url = URI.parse(options.fetch(:url))
+    @hostname = "#{url.host}:#{url.port}"
+
+    super
+  end
+
+  def rewrite_env(env)
+    env["HTTP_HOST"] = @hostname
+    env
+  end
+end


### PR DESCRIPTION
Prototypes the use of rack-proxy for this.

To test it out, provide the optional configuration variable which enables the proxying functionality.

		NEW_APP_URL=http://localhost:3000/ rails s -p 3001

This has uncovered a few issues:

* What to do about assets? Currently I've found yet another way to generate unstyled pages...
* What about HTTPS requests? Should they be proxied over SSL?

The paths to proxy currently hardcoded as /en/... and /cy/...