### PR TITLE
Redirect proportion of sessions to new app

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,9 @@ Source: `config/environments/development.rb` and `config/environments`.
 This is used to test after 28 days in advance. It is optional.
 
 - `OVERRIDE_BOOKING_WINDOW`
+
+### Redirecting traffic to the new app
+
+Supports redirecting a proportion of new booking requests to the new prison visits application. Should be a value between 0 (no requests redirected) and 1 (all requests redirected).
+
+- `NEW_APP_PROBABILITY`

--- a/app/controllers/start_page_controller.rb
+++ b/app/controllers/start_page_controller.rb
@@ -1,0 +1,21 @@
+class StartPageController < ApplicationController
+  NEW_APP_PROBABILITY_DEFAULT = 0.1
+
+  # Used to redirect a (controllable) portion of requests to the new
+  # prison-visits application, which is proxied at /en/
+  def show
+    # The probability that any given user will be redirected to the new app
+    new_app_probability = NEW_APP_PROBABILITY_DEFAULT
+
+    # Store a random number between 0 and 1 in the session so that the choice
+    # of which app a user is directed to is fixed with respect to the value of
+    # new_app_probability
+    threshold = request.session[:app_choice_threshold] ||= rand
+
+    if threshold < new_app_probability
+      redirect_to '/en/request'
+    else
+      redirect_to '/prisoner'
+    end
+  end
+end

--- a/app/controllers/start_page_controller.rb
+++ b/app/controllers/start_page_controller.rb
@@ -1,11 +1,9 @@
 class StartPageController < ApplicationController
-  NEW_APP_PROBABILITY_DEFAULT = 0.1
-
   # Used to redirect a (controllable) portion of requests to the new
   # prison-visits application, which is proxied at /en/
   def show
     # The probability that any given user will be redirected to the new app
-    new_app_probability = NEW_APP_PROBABILITY_DEFAULT
+    new_app_probability = Rails.configuration.new_app_probability
 
     # Store a random number between 0 and 1 in the session so that the choice
     # of which app a user is directed to is fixed with respect to the value of

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,6 @@ module PrisonVisits2
       'assets', 'moj.slot-picker', 'dist', 'stylesheets')
     config.middleware.delete 'ActiveRecord::QueryCache'
     config.session_expire_after = 20.minutes
+    config.new_app_probability = ENV.fetch('NEW_APP_PROBABILITY', 0).to_f
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,10 @@ PrisonVisits2::Application.routes.draw do
   get "/healthcheck.json", controller: 'healthcheck', action: 'index'
 
   # Legacy URLs
-  get "/prisoner-details", to: redirect("/prisoner")
+
+  # This is route used by the gov.uk start page
+  get "/prisoner-details", to: 'start_page#show'
+
   get "/deferred/confirmation/new" => "confirmations#new"
 
   get "/", to: redirect(ENV.fetch("GOVUK_START_PAGE", "/prisoner"))

--- a/spec/controllers/start_page_controller_spec.rb
+++ b/spec/controllers/start_page_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe StartPageController, type: :controller do
+  describe 'show' do
+    let :configured_probability do
+      StartPageController::NEW_APP_PROBABILITY_DEFAULT
+    end
+
+    it 'stores a random threshold in the user\'s session' do
+      get :show
+      expect(session[:app_choice_threshold]).to be_in(0..1)
+    end
+
+    it "redirects to the new app if the user's threshold is low" do
+      session[:app_choice_threshold] = rand(0..configured_probability)
+      get :show
+      expect(response).to redirect_to('/en/request')
+    end
+
+    it "redirects to this (old) app if the user's threshold is high" do
+      session[:app_choice_threshold] = rand(configured_probability..1)
+      get :show
+      expect(response).to redirect_to('/prisoner')
+    end
+  end
+end

--- a/spec/controllers/start_page_controller_spec.rb
+++ b/spec/controllers/start_page_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe StartPageController, type: :controller do
   describe 'show' do
-    let :configured_probability do
-      StartPageController::NEW_APP_PROBABILITY_DEFAULT
+    before :each do
+      Rails.configuration.new_app_probability = 0.2
     end
 
     it 'stores a random threshold in the user\'s session' do
@@ -12,13 +12,13 @@ RSpec.describe StartPageController, type: :controller do
     end
 
     it "redirects to the new app if the user's threshold is low" do
-      session[:app_choice_threshold] = rand(0..configured_probability)
+      session[:app_choice_threshold] = 0.1
       get :show
       expect(response).to redirect_to('/en/request')
     end
 
     it "redirects to this (old) app if the user's threshold is high" do
-      session[:app_choice_threshold] = rand(configured_probability..1)
+      session[:app_choice_threshold] = 0.3
       get :show
       expect(response).to redirect_to('/prisoner')
     end


### PR DESCRIPTION
Notes

* A threshold is stored in the user's session so that they get the same experience each time (until the configured probability is altered).
* Safe to merge and deploy – the default behaviour redirects 0% of requests.