### PR TITLE
Redirect remaining traffic to the new app

### DIFF
--- a/app/controllers/prisoner_details_controller.rb
+++ b/app/controllers/prisoner_details_controller.rb
@@ -5,7 +5,14 @@ class PrisonerDetailsController < ApplicationController
 
   before_action :logstasher_add_visit_id_from_session, only: :update
 
+  # rubocop:disable Metrics/MethodLength
   def edit
+    # Permanently redirect to the new app if we've got to probability 1
+    new_app_probability = Rails.configuration.new_app_probability
+    if new_app_probability == 1
+      redirect_to '/en/request', status: :moved_permanently
+    end
+
     session[:visit] ||= new_session
     logstasher_add_visit_id(visit.visit_id)
     response.set_cookie(
@@ -17,6 +24,7 @@ class PrisonerDetailsController < ApplicationController
       path: '/'
     )
   end
+  # rubocop:enable Metrics/MethodLength
 
   def update
     if (visit.prisoner = Prisoner.new(prisoner_params)).valid?

--- a/spec/controllers/start_page_controller_spec.rb
+++ b/spec/controllers/start_page_controller_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe StartPageController, type: :controller do
       Rails.configuration.new_app_probability = 0.2
     end
 
+    after :each do
+      Rails.configuration.new_app_probability = 0
+    end
+
     it 'stores a random threshold in the user\'s session' do
       get :show
       expect(session[:app_choice_threshold]).to be_in(0..1)


### PR DESCRIPTION
I'm using a permanent redirect to encourage browsers to cache the change. I don't foresee reverting this change.